### PR TITLE
fix(hazard-maps): show low-hazard areas in yellow

### DIFF
--- a/src/app/shared/mocks/flood.ts
+++ b/src/app/shared/mocks/flood.ts
@@ -10,20 +10,16 @@ export const LEYTE_FLOOD: FillLayer = {
   'source-layer': 'Leyte_Flood_100year-15dhkm',
   paint: {
     'fill-color': [
-      'step',
+      'interpolate',
+      ['linear'],
       ['get', 'Var'],
-      'hsl(50, 99%, 82%)',
       1,
-      [
-        'match',
-        ['get', 'Var'],
-        0,
-        'hsla(0, 100%, 68%, 0.89)',
-        'hsl(27, 100%, 51%)',
-      ],
+      '#f2c94c',
+      2,
+      '#f2994a',
       3,
-      ['match', ['get', 'Var'], [3], 'rgb(255, 0, 0)', '#000000'],
+      '#eb5757',
     ],
-    'fill-opacity': 0.75,
+    'fill-opacity': 0.9,
   },
 };

--- a/src/app/shared/mocks/landslide.ts
+++ b/src/app/shared/mocks/landslide.ts
@@ -10,20 +10,16 @@ export const LEYTE_LANDSLIDE: FillLayer = {
   'source-layer': 'Leyte_LandslideHazard-beq0xe',
   paint: {
     'fill-color': [
-      'step',
+      'interpolate',
+      ['linear'],
       ['get', 'LH'],
-      'hsl(50, 99%, 82%)',
       1,
-      [
-        'match',
-        ['get', 'LH'],
-        0,
-        'hsla(0, 100%, 68%, 0.89)',
-        'hsl(27, 100%, 51%)',
-      ],
+      '#f2c94c',
+      2,
+      '#f2994a',
       3,
-      ['match', ['get', 'LH'], [3], 'rgb(255, 0, 0)', '#000000'],
+      '#eb5757',
     ],
-    'fill-opacity': 0.75,
+    'fill-opacity': 0.9,
   },
 };

--- a/src/app/shared/mocks/storm-surges.ts
+++ b/src/app/shared/mocks/storm-surges.ts
@@ -10,20 +10,16 @@ export const LEYTE_STORM_SURGE: FillLayer = {
   'source-layer': 'Leyte_StormSurge_SSA4-93raju',
   paint: {
     'fill-color': [
-      'step',
+      'interpolate',
+      ['linear'],
       ['get', 'HAZ'],
-      'hsl(50, 99%, 82%)',
       1,
-      [
-        'match',
-        ['get', 'HAZ'],
-        0,
-        'hsla(0, 100%, 68%, 0.89)',
-        'hsl(27, 100%, 51%)',
-      ],
+      '#f2c94c',
+      2,
+      '#f2994a',
       3,
-      ['match', ['get', 'HAZ'], [3], 'rgb(255, 0, 0)', '#000000'],
+      '#eb5757',
     ],
-    'fill-opacity': 0.75,
+    'fill-opacity': 0.9,
   },
 };


### PR DESCRIPTION
# Task description

- As raised by Sir Mahar during last week's meeting, we also need to show the low-hazard areas in yellow
- We only had to change the fill-color specified in mapbox styles

# Screenshot

![image](https://user-images.githubusercontent.com/11599005/117526745-a0894400-aff9-11eb-869e-da6a4b3a95c0.png)
![image](https://user-images.githubusercontent.com/11599005/117526771-d29aa600-aff9-11eb-8e76-c664b667fb21.png)
