### PR TITLE
feat(playground): change layer opacity and change zoom level in initmap

### DIFF
--- a/src/app/features/noah-playground/components/map-playground/map-playground.component.ts
+++ b/src/app/features/noah-playground/components/map-playground/map-playground.component.ts
@@ -287,7 +287,7 @@ export class MapPlaygroundComponent implements OnInit, OnDestroy {
     this.map = new mapboxgl.Map({
       container: 'map',
       style: environment.mapbox.styles.terrain,
-      zoom: 10,
+      zoom: 5,
       touchZoomRotate: true,
       center: this.pgService.currentCoords,
     });

--- a/src/app/features/noah-playground/store/noah-playground.store.ts
+++ b/src/app/features/noah-playground/store/noah-playground.store.ts
@@ -108,17 +108,17 @@ const createInitialValue = (): NoahPlaygroundState => ({
     expanded: true,
     levels: {
       'flood-return-period-5': {
-        opacity: 100,
+        opacity: 85,
         color: 'noah-red',
         shown: false,
       },
       'flood-return-period-25': {
-        opacity: 100,
+        opacity: 85,
         color: 'noah-red',
         shown: true,
       },
       'flood-return-period-100': {
-        opacity: 100,
+        opacity: 85,
         color: 'noah-red',
         shown: false,
       },
@@ -129,7 +129,7 @@ const createInitialValue = (): NoahPlaygroundState => ({
     expanded: false,
     levels: {
       'landslide-hazard': {
-        opacity: 100,
+        opacity: 85,
         color: 'noah-red',
         shown: false,
       },
@@ -139,12 +139,12 @@ const createInitialValue = (): NoahPlaygroundState => ({
       //   shown: false,
       // },
       'debris-flow': {
-        opacity: 100,
+        opacity: 85,
         color: 'noah-red',
         shown: false,
       },
       'unstable-slopes-maps': {
-        opacity: 100,
+        opacity: 85,
         color: 'noah-red',
         shown: false,
       },
@@ -155,22 +155,22 @@ const createInitialValue = (): NoahPlaygroundState => ({
     expanded: false,
     levels: {
       'storm-surge-advisory-1': {
-        opacity: 100,
+        opacity: 85,
         color: 'noah-red',
         shown: false,
       },
       'storm-surge-advisory-2': {
-        opacity: 100,
+        opacity: 85,
         color: 'noah-red',
         shown: false,
       },
       'storm-surge-advisory-3': {
-        opacity: 100,
+        opacity: 85,
         color: 'noah-red',
         shown: false,
       },
       'storm-surge-advisory-4': {
-        opacity: 100,
+        opacity: 85,
         color: 'noah-red',
         shown: false,
       },


### PR DESCRIPTION
## Changes

- Change default opacity value from 100 to 85 hazard layers in playground

## Screenshots
### old
![image](https://user-images.githubusercontent.com/76890692/129848731-ea0b9aa5-0cb6-4ca0-850a-bb22b89a66f8.png)

### new
![image](https://user-images.githubusercontent.com/76890692/129849172-15400196-f08c-4f70-9a3c-59f922a6a49b.png)
