### PR TITLE
feat(playground): multilayer and multi-source combo

### DIFF
--- a/src/app/features/noah-playground/components/map-playground/map-playground.component.ts
+++ b/src/app/features/noah-playground/components/map-playground/map-playground.component.ts
@@ -64,9 +64,9 @@ export class MapPlaygroundComponent implements OnInit, OnDestroy {
     fromEvent(this.map, 'style.load')
       .pipe(takeUntil(this._unsub))
       .subscribe(() => {
-        // this.initMarkers();
-        // this.addExaggerationControl();
-        // this.addCriticalFacilityLayers();
+        this.initMarkers();
+        this.addExaggerationControl();
+        this.addCriticalFacilityLayers();
         // this.initHazardLayers();
         this.initComboHazardLayers();
       });

--- a/src/app/features/noah-playground/components/map-playground/map-playground.component.ts
+++ b/src/app/features/noah-playground/components/map-playground/map-playground.component.ts
@@ -8,6 +8,7 @@ import { NoahPlaygroundService } from '@features/noah-playground/services/noah-p
 import {
   debounceTime,
   distinctUntilChanged,
+  filter,
   map,
   takeUntil,
   tap,
@@ -21,7 +22,11 @@ import {
 } from '@shared/mocks/critical-facilities';
 import MapboxGeocoder from '@mapbox/mapbox-gl-geocoder';
 import '@mapbox/mapbox-gl-geocoder/dist/mapbox-gl-geocoder.css';
-
+import PH_COMBO_LAYERS from '@shared/data/ph_combined_tileset.json';
+import {
+  HazardLevel,
+  HazardType,
+} from '@features/noah-playground/store/noah-playground.store';
 type MapStyle = 'terrain' | 'satellite';
 
 @Component({
@@ -59,10 +64,11 @@ export class MapPlaygroundComponent implements OnInit, OnDestroy {
     fromEvent(this.map, 'style.load')
       .pipe(takeUntil(this._unsub))
       .subscribe(() => {
-        this.initMarkers();
-        this.addExaggerationControl();
-        this.addCriticalFacilityLayers();
-        this.initHazardLayers();
+        // this.initMarkers();
+        // this.addExaggerationControl();
+        // this.addCriticalFacilityLayers();
+        // this.initHazardLayers();
+        this.initComboHazardLayers();
       });
   }
 
@@ -189,6 +195,148 @@ export class MapPlaygroundComponent implements OnInit, OnDestroy {
 
         this.map.setTerrain({ source: 'mapbox-dem', exaggeration: 0 });
       });
+  }
+
+  initComboHazardLayers() {
+    PH_COMBO_LAYERS.forEach((comboLayerObj) => {
+      const sourceID = comboLayerObj.url.replace('mapbox://prince-test.', '');
+      const sourceData = {
+        type: 'vector',
+        url: comboLayerObj.url,
+      } as mapboxgl.AnySourceData;
+      this.map.addSource(sourceID, sourceData);
+
+      comboLayerObj.sourceLayer.forEach((sourceLayer) => {
+        const [rawHazardType, rawHazardLevel] = [
+          ...sourceLayer.toLowerCase().split('_').splice(1),
+        ];
+
+        const hazardTypes = {
+          fh: 'flood',
+          lh: 'landslide',
+          ssh: 'storm-surge',
+        };
+
+        const getHazardLevel = (
+          type: HazardType,
+          level: string
+        ): HazardLevel => {
+          if (type === 'flood') {
+            const strippedLevel = level.replace('yr', '');
+            return `flood-return-period-${strippedLevel}` as HazardLevel;
+          }
+
+          if (type === 'storm-surge') {
+            const strippedLevel = level.replace('ssa', '');
+            return `storm-surge-advisory-${strippedLevel}` as HazardLevel;
+          }
+
+          if (type === 'landslide') {
+            // We currently have only one shown
+            return 'landslide-hazard';
+          }
+
+          throw Error('hazard level not found');
+        };
+
+        const hazardType = hazardTypes[rawHazardType];
+        const hazardLevel = getHazardLevel(hazardType, rawHazardLevel);
+
+        // const layerID = `${sourceID}_${hazardType}_${hazardLevel}`;
+        const layerID = sourceLayer;
+        this.map.addLayer({
+          id: layerID,
+          type: 'fill',
+          source: sourceID,
+          'source-layer': sourceLayer,
+          paint: {
+            'fill-color': getHazardColor(hazardType, 'noah-red', hazardType),
+            'fill-opacity': 0.75,
+          },
+        });
+
+        // OPACITY
+        this.pgService
+          .getHazardLevel$(hazardType, hazardLevel)
+          .pipe(
+            takeUntil(this._unsub),
+            takeUntil(this._changeStyle),
+            filter((level) => !!level),
+            distinctUntilChanged((x, y) => x.opacity !== y.opacity)
+          )
+          .subscribe((level) =>
+            this.map.setPaintProperty(
+              layerID,
+              'fill-opacity',
+              level.opacity / 100
+            )
+          );
+
+        // VISIBILITY
+        const hazardType$ = this.pgService.getHazard$(hazardType).pipe(
+          takeUntil(this._unsub),
+          takeUntil(this._changeStyle),
+          distinctUntilChanged((x, y) => x.shown === y.shown)
+        );
+
+        const hazardLevel$ = this.pgService
+          .getHazardLevel$(hazardType, hazardLevel)
+          .pipe(
+            takeUntil(this._unsub),
+            takeUntil(this._changeStyle),
+            distinctUntilChanged((x, y) => x.shown !== y.shown)
+          );
+
+        combineLatest([hazardType$, hazardLevel$])
+          .pipe(
+            filter(
+              ([hazardTypeValue, hazardLevelValue]) =>
+                !!hazardTypeValue && !!hazardLevelValue
+            )
+            // tap(([hazardTypeValue, hazardLevelValue]) => {
+            //   if (hazardTypeValue === 'flood' && !environment.production) {
+            //     console.log(
+            //       'hazardTypeShown',
+            //       hazardTypeValue.shown,
+            //       'hazardLevelShown',
+            //       hazardLevelValue.shown,
+            //       h.name,
+            //       hl.name
+            //     );
+            //   }
+            // })
+          )
+          .subscribe(([hazardTypeValue, hazardLevelValue]) => {
+            if (hazardTypeValue.shown && hazardLevelValue.shown) {
+              this.map.setPaintProperty(
+                layerID,
+                'fill-opacity',
+                hazardLevelValue.opacity / 100
+              );
+              return;
+            }
+
+            this.map.setPaintProperty(layerID, 'fill-opacity', 0);
+          });
+
+        // COLOR
+        this.pgService
+          .getHazardLevel$(hazardType, hazardLevel)
+          .pipe(
+            takeUntil(this._unsub),
+            takeUntil(this._changeStyle),
+            filter((level) => !!level),
+            distinctUntilChanged((x, y) => x.color !== y.color)
+          )
+          .subscribe((level) =>
+            this.map.setPaintProperty(
+              layerID,
+              'fill-color',
+              getHazardColor(hazardType, level.color, layerID)
+            )
+          );
+      });
+    });
   }
 
   initHazardLayers() {

--- a/src/app/shared/data/ph_combined_tileset.json
+++ b/src/app/shared/data/ph_combined_tileset.json
@@ -1,0 +1,176 @@
+[
+  {
+    "url": "mapbox://prince-test.ph_fh_100yr_tls",
+    "sourceLayer": [
+      "PH010000000_FH_100yr",
+      "PH020000000_FH_100yr",
+      "PH040000000_FH_100yr",
+      "PH050000000_FH_100yr",
+      "PH060000000_FH_100yr",
+      "PH070000000_FH_100yr",
+      "PH080000000_FH_100yr",
+      "PH090000000_FH_100yr",
+      "PH100000000_FH_100yr",
+      "PH110000000_FH_100yr",
+      "PH120000000_FH_100yr",
+      "PH130000000_FH_100yr",
+      "PH140000000_FH_100yr",
+      "PH150000000_FH_100yr",
+      "PH160000000_FH_100yr",
+      "PH170000000_FH_100yr",
+      "PH180000000_FH_100yr"
+    ]
+  },
+  {
+    "url": "mapbox://prince-test.ph_fh_25yr_tls",
+    "sourceLayer": [
+      "PH010000000_FH_25yr",
+      "PH020000000_FH_25yr",
+      "PH030000000_FH_25yr",
+      "PH040000000_FH_25yr",
+      "PH050000000_FH_25yr",
+      "PH060000000_FH_25yr",
+      "PH070000000_FH_25yr",
+      "PH080000000_FH_25yr",
+      "PH090000000_FH_25yr",
+      "PH100000000_FH_25yr",
+      "PH110000000_FH_25yr",
+      "PH120000000_FH_25yr",
+      "PH130000000_FH_25yr",
+      "PH140000000_FH_25yr",
+      "PH150000000_FH_25yr",
+      "PH160000000_FH_25yr",
+      "PH170000000_FH_25yr",
+      "PH180000000_FH_25yr"
+    ]
+  },
+  {
+    "url": "mapbox://prince-test.ph_fh_5yr_tls",
+    "sourceLayer": [
+      "PH010000000_FH_5yr",
+      "PH020000000_FH_5yr",
+      "PH030000000_FH_5yr",
+      "PH040000000_FH_5yr",
+      "PH050000000_FH_5yr",
+      "PH060000000_FH_5yr",
+      "PH070000000_FH_5yr",
+      "PH080000000_FH_5yr",
+      "PH100000000_FH_5yr",
+      "PH120000000_FH_5yr",
+      "PH130000000_FH_5yr",
+      "PH140000000_FH_5yr",
+      "PH150000000_FH_5yr",
+      "PH160000000_FH_5yr",
+      "PH170000000_FH_5yr"
+    ]
+  },
+  {
+    "url": "mapbox://prince-test.ph_lh_lh1_tls",
+    "sourceLayer": [
+      "PH010000000_LH_lh1",
+      "PH020000000_LH_lh1",
+      "PH030000000_LH_lh1",
+      "PH040000000_LH_lh1",
+      "PH050000000_LH_lh1",
+      "PH060000000_LH_lh1",
+      "PH070000000_LH_lh1",
+      "PH080000000_LH_lh1",
+      "PH100000000_LH_lh1",
+      "PH110000000_LH_lh1",
+      "PH120000000_LH_lh1",
+      "PH130000000_LH_lh1",
+      "PH140000000_LH_lh1",
+      "PH150000000_LH_lh1",
+      "PH160000000_LH_lh1",
+      "PH170000000_LH_lh1",
+      "PH180000000_LH_lh1"
+    ]
+  },
+  {
+    "url": "mapbox://prince-test.ph_ssh_ssa1_tls",
+    "sourceLayer": [
+      "PH010000000_SSH_ssa1",
+      "PH020000000_SSH_ssa1",
+      "PH030000000_SSH_ssa1",
+      "PH040000000_SSH_ssa1",
+      "PH050000000_SSH_ssa1",
+      "PH060000000_SSH_ssa1",
+      "PH070000000_SSH_ssa1",
+      "PH080000000_SSH_ssa1",
+      "PH090000000_SSH_ssa1",
+      "PH100000000_SSH_ssa1",
+      "PH120000000_SSH_ssa1",
+      "PH130000000_SSH_ssa1",
+      "PH150000000_SSH_ssa1",
+      "PH160000000_SSH_ssa1",
+      "PH170000000_SSH_ssa1",
+      "PH180000000_SSH_ssa1"
+    ]
+  },
+  {
+    "url": "mapbox://prince-test.ph_ssh_ssa2_tls",
+    "sourceLayer": [
+      "PH010000000_SSH_ssa2",
+      "PH020000000_SSH_ssa2",
+      "PH030000000_SSH_ssa2",
+      "PH040000000_SSH_ssa2",
+      "PH050000000_SSH_ssa2",
+      "PH060000000_SSH_ssa2",
+      "PH070000000_SSH_ssa2",
+      "PH080000000_SSH_ssa2",
+      "PH090000000_SSH_ssa2",
+      "PH100000000_SSH_ssa2",
+      "PH110000000_SSH_ssa2",
+      "PH120000000_SSH_ssa2",
+      "PH130000000_SSH_ssa2",
+      "PH150000000_SSH_ssa2",
+      "PH160000000_SSH_ssa2",
+      "PH170000000_SSH_ssa2",
+      "PH180000000_SSH_ssa2"
+    ]
+  },
+  {
+    "url": "mapbox://prince-test.ph_ssh_ssa3_tls",
+    "sourceLayer": [
+      "PH010000000_SSH_ssa3",
+      "PH020000000_SSH_ssa3",
+      "PH030000000_SSH_ssa3",
+      "PH040000000_SSH_ssa3",
+      "PH050000000_SSH_ssa3",
+      "PH060000000_SSH_ssa3",
+      "PH070000000_SSH_ssa3",
+      "PH080000000_SSH_ssa3",
+      "PH090000000_SSH_ssa3",
+      "PH100000000_SSH_ssa3",
+      "PH110000000_SSH_ssa3",
+      "PH120000000_SSH_ssa3",
+      "PH130000000_SSH_ssa3",
+      "PH150000000_SSH_ssa3",
+      "PH160000000_SSH_ssa3",
+      "PH170000000_SSH_ssa3",
+      "PH180000000_SSH_ssa3"
+    ]
+  },
+  {
+    "url": "mapbox://prince-test.ph_ssh_ssa4_tls",
+    "sourceLayer": [
+      "PH010000000_SSH_ssa4",
+      "PH020000000_SSH_ssa4",
+      "PH030000000_SSH_ssa4",
+      "PH040000000_SSH_ssa4",
+      "PH050000000_SSH_ssa4",
+      "PH060000000_SSH_ssa4",
+      "PH070000000_SSH_ssa4",
+      "PH080000000_SSH_ssa4",
+      "PH090000000_SSH_ssa4",
+      "PH100000000_SSH_ssa4",
+      "PH110000000_SSH_ssa4",
+      "PH120000000_SSH_ssa4",
+      "PH130000000_SSH_ssa4",
+      "PH150000000_SSH_ssa4",
+      "PH160000000_SSH_ssa4",
+      "PH170000000_SSH_ssa4",
+      "PH180000000_SSH_ssa4"
+    ]
+  }
+]


### PR DESCRIPTION
# Summary

In this PR, we're exploring the effects of combining multiple hazard layers into a single tileset per hazard type-level combo for the whole Philippines. That said, we now just have 8 tilesets as opposed to >800 tilesets with only 1 layer each before.

# Findings

## 1 - Takes 5 seconds to load everything 

![image](https://user-images.githubusercontent.com/11599005/132127670-aa34f2e6-0109-4e71-8789-bf665cd66dc3.png)

## There are no more hiccups when zooming the map in or out 

**Notes**

- The critical facilities are not loaded while testing this. Loading them still causes the page to lag while zooming in or out

![Kapture 2021-09-05 at 21 00 20](https://user-images.githubusercontent.com/11599005/132127784-6ec5b3f7-bb0e-4415-86c0-a9792e66e90f.gif)

- We're using tilesets from @pfgoting's account. I created another ticket to load the tickets from UPRI's official mapbox account here: https://github.com/UPRI-NOAH/noah-frontend/issues/145
- I haven't deleted the previous implementation yet. I'll address that in another PR