### PR TITLE
fix(know-your-hazard): display optimized PH-wide maps

### DIFF
--- a/src/app/features/know-your-hazards/components/map-kyh/map-kyh.component.ts
+++ b/src/app/features/know-your-hazards/components/map-kyh/map-kyh.component.ts
@@ -58,11 +58,6 @@ export class MapKyhComponent implements OnInit {
       .subscribe(() => {
         this.initLayers();
         this.initMarkers();
-        this.hideAllLayers();
-        this.initPageListener();
-
-        const page = this.kyhService.currentPage;
-        this.showLayers(page);
       });
   }
 
@@ -157,8 +152,6 @@ export class MapKyhComponent implements OnInit {
       );
 
       tileset.sourceLayer.forEach((layerName: string) => {
-        console.log(rawHazardType, rawHazardLevel, layerName);
-
         if (hazardLevel === 'debris-flow') {
           const [rawHazardType, lh2Subtype] = [
             ...layerName.toLowerCase().split('_').splice(1),
@@ -230,14 +223,6 @@ export class MapKyhComponent implements OnInit {
     });
   }
 
-  initPageListener() {
-    this.kyhService.currentPage$
-      .pipe(takeUntil(this._unsub))
-      .subscribe((page) => {
-        this.showLayers(page);
-      });
-  }
-
   initMap() {
     this.mapService.init();
     this.map = new mapboxgl.Map({
@@ -294,32 +279,10 @@ export class MapKyhComponent implements OnInit {
     });
   }
 
-  hideAllLayers() {
-    this.kyhService.hazardTypes.forEach((hazard) => {
-      this.map.setLayoutProperty(hazard, 'visibility', 'none');
-    });
-  }
-
-  showAllLayers() {
-    this.kyhService.hazardTypes.forEach((hazard) => {
-      this.map.setLayoutProperty(hazard, 'visibility', 'visible');
-    });
-  }
-
   showCurrentHazardLayer(currentHazard: HazardType) {
     if (!this.kyhService.isHazardLayer(currentHazard)) return;
 
     this.map.setLayoutProperty(currentHazard, 'visibility', 'visible');
-  }
-
-  showLayers(page: KYHPage) {
-    if (page === 'know-your-hazards') {
-      this.showAllLayers();
-      return;
-    }
-
-    this.hideAllLayers();
-    this.showCurrentHazardLayer(page as HazardType);
   }
 
   switchMapStyle(style: MapStyle) {

--- a/src/app/features/know-your-hazards/components/map-kyh/map-kyh.component.ts
+++ b/src/app/features/know-your-hazards/components/map-kyh/map-kyh.component.ts
@@ -22,6 +22,7 @@ import {
 } from '@features/know-your-hazards/store/kyh.store';
 import { getHazardColor } from '@shared/mocks/flood';
 import { HazardLevel } from '@features/noah-playground/store/noah-playground.store';
+import { NOAH_COLORS } from '@shared/mocks/noah-colors';
 
 type MapStyle = 'terrain' | 'satellite';
 
@@ -135,60 +136,96 @@ export class MapKyhComponent implements OnInit {
   }
 
   initLayers() {
-    PH_COMBO_LAYERS.forEach((comboLayerObj) => {
-      const sourceID = comboLayerObj.url.replace('mapbox://prince-test.', '');
+    PH_COMBO_LAYERS.forEach((tileset) => {
       const sourceData = {
         type: 'vector',
-        url: comboLayerObj.url,
+        url: tileset.url,
       } as mapboxgl.AnySourceData;
+      const sourceID = tileset.url.replace('mapbox://upri-noah.', '');
+      // 1. Add source first
       this.map.addSource(sourceID, sourceData);
 
-      comboLayerObj.sourceLayer.forEach((sourceLayer) => {
-        const [rawHazardType, rawHazardLevel] = [
-          ...sourceLayer.toLowerCase().split('_').splice(1),
-        ];
+      // 2. Get the hazard type and level
+      const [rawHazardType, rawHazardLevel] = [
+        ...sourceID.toLowerCase().split('_').splice(1),
+      ];
 
-        const hazardTypes = {
-          fh: 'flood',
-          lh: 'landslide',
-          ssh: 'storm-surge',
-        };
+      const hazardType = getHazardType(rawHazardType as RawHazardType);
+      const hazardLevel = getHazardLevel(
+        rawHazardType as RawHazardType,
+        rawHazardLevel as RawHazardLevel
+      );
 
-        const getHazardLevel = (
-          type: HazardType,
-          level: string
-        ): HazardLevel => {
-          if (type === 'flood') {
-            const strippedLevel = level.replace('yr', '');
-            return `flood-return-period-${strippedLevel}` as HazardLevel;
+      tileset.sourceLayer.forEach((layerName: string) => {
+        console.log(rawHazardType, rawHazardLevel, layerName);
+
+        if (hazardLevel === 'debris-flow') {
+          const [rawHazardType, lh2Subtype] = [
+            ...layerName.toLowerCase().split('_').splice(1),
+          ];
+          if (lh2Subtype === 'af') {
+            this.map.addLayer({
+              id: layerName,
+              type: 'line',
+              source: sourceID,
+              'source-layer': layerName,
+              paint: {
+                'line-width': 2,
+                'line-color': [
+                  'interpolate',
+                  ['linear'],
+                  ['get', 'ALLUVIAL'],
+                  4,
+                  NOAH_COLORS['noah-black'].high,
+                ],
+                'line-opacity': 0.75,
+              },
+            });
           }
 
-          if (type === 'storm-surge') {
-            const strippedLevel = level.replace('ssa', '');
-            return `storm-surge-advisory-${strippedLevel}` as HazardLevel;
+          if (lh2Subtype === 'df') {
+            this.map.addLayer({
+              id: layerName,
+              type: 'fill',
+              source: sourceID,
+              'source-layer': layerName,
+              paint: {
+                'fill-color': [
+                  'interpolate',
+                  ['linear'],
+                  ['get', 'ALLUVIAL'],
+                  3,
+                  NOAH_COLORS['noah-red'].high,
+                ],
+                'fill-opacity': 0.75,
+              },
+            });
           }
+        } else {
+          this.map.addLayer({
+            id: layerName,
+            type: 'fill',
+            source: sourceID,
+            'source-layer': layerName,
+            paint: {
+              'fill-color': getHazardColor(hazardType, 'noah-red', hazardLevel),
+              'fill-opacity': 0.75,
+            },
+          });
+        }
 
-          if (type === 'landslide') {
-            // We currently have only one shown
-            return 'landslide-hazard';
-          }
-
-          throw Error('hazard level not found');
-        };
-
-        const hazardType = hazardTypes[rawHazardType];
-
-        const layerID = sourceLayer;
-        this.map.addLayer({
-          id: layerID,
-          type: 'fill',
-          source: sourceID,
-          'source-layer': sourceLayer,
-          paint: {
-            'fill-color': getHazardColor(hazardType, 'noah-red', hazardType),
-            'fill-opacity': 0.75,
-          },
-        });
+        // add visibility watcher
+        this.kyhService
+          .isHazardShown$(hazardType)
+          .pipe(
+            takeUntil(this._unsub),
+            // takeUntil(this._changeStyle),
+            distinctUntilChanged()
+          )
+          .subscribe((shown: boolean) => {
+            const visibility = shown ? 'visible' : 'none';
+            this.map.setLayoutProperty(layerName, 'visibility', visibility);
+          });
       });
     });
   }
@@ -293,4 +330,73 @@ export class MapKyhComponent implements OnInit {
       this.map.setStyle(environment.mapbox.styles[style]);
     }
   }
+}
+
+type RawHazardType = 'lh' | 'fh' | 'ssh';
+type RawHazardLevel =
+  | RawFloodReturnPeriod
+  | RawStormSurgeAdvisory
+  | RawLandslideHazards;
+
+export type RawFloodReturnPeriod = '5yr' | '25yr' | '100yr';
+
+export type RawStormSurgeAdvisory = 'ssa1' | 'ssa2' | 'ssa3' | 'ssa4';
+
+export type RawLandslideHazards =
+  | 'lh1' // landslide
+  | 'lh2' // alluvial fan and debris flow
+  | 'lh3'; // unstable slopes
+
+type LH2Subtype = 'af' | 'df';
+
+function getHazardType(rawHazardType: RawHazardType): HazardType {
+  switch (rawHazardType) {
+    case 'fh':
+      return 'flood';
+    case 'lh':
+      return 'landslide';
+    case 'ssh':
+      return 'storm-surge';
+    default:
+      break;
+  }
+  throw new Error(`Cannot find hazard type ${rawHazardType}`);
+}
+
+function getHazardLevel(
+  rawHazardType: RawHazardType,
+  rawHazardLevel: RawHazardLevel
+): HazardLevel {
+  switch (rawHazardType) {
+    case 'fh':
+      const strippedFloodLevel = rawHazardLevel.replace('yr', '');
+      return `flood-return-period-${strippedFloodLevel}` as HazardLevel;
+    case 'lh':
+      return handleLandslideLevel(
+        rawHazardLevel as RawLandslideHazards
+      ) as HazardLevel;
+    case 'ssh':
+      const strippedSSHLevel = rawHazardLevel.replace('ssa', '');
+      return `storm-surge-advisory-${strippedSSHLevel}` as HazardLevel;
+    default:
+      break;
+  }
+
+  throw new Error(`Cannot find hazard type ${rawHazardType}`);
+}
+
+function handleLandslideLevel(level: RawLandslideHazards): string {
+  switch (level) {
+    case 'lh1':
+      return 'landslide-hazard';
+    case 'lh2':
+      // returns debris-flow for both debris-flow and alluvial fan
+      return 'debris-flow';
+    case 'lh3':
+      return 'unstable-slopes-maps';
+    default:
+      break;
+  }
+
+  throw new Error(`Cannot find hazard level ${level}`);
 }

--- a/src/app/features/know-your-hazards/pages/know-your-hazards/know-your-hazards.component.ts
+++ b/src/app/features/know-your-hazards/pages/know-your-hazards/know-your-hazards.component.ts
@@ -57,7 +57,6 @@ export class KnowYourHazardsComponent implements OnInit {
   }
 
   viewHazardLayer(currentHazard: HazardType) {
-    this.kyhService.setCurrentHazard(currentHazard);
     this.kyhService.setCurrentPage(currentHazard);
   }
 

--- a/src/app/features/know-your-hazards/services/kyh.service.ts
+++ b/src/app/features/know-your-hazards/services/kyh.service.ts
@@ -7,6 +7,7 @@ import {
   KYHPage,
   RiskLevel,
   PH_DEFAULT_CENTER,
+  ExposureLevel,
 } from '../store/kyh.store';
 import { HazardsService } from './hazards.service';
 
@@ -109,6 +110,16 @@ export class KyhService {
 
   init() {
     this.assessRisk();
+  }
+
+  getHazardExposureLevel$(hazardType: HazardType): Observable<ExposureLevel> {
+    return this.kyhStore.state$.pipe(
+      map((state) => state[hazardType].exposureLevel)
+    );
+  }
+
+  isHazardShown$(hazardType: HazardType): Observable<boolean> {
+    return this.kyhStore.state$.pipe(map((state) => state[hazardType].shown));
   }
 
   isHazardLayer(currentHazard: HazardType): boolean {

--- a/src/app/features/know-your-hazards/services/kyh.service.ts
+++ b/src/app/features/know-your-hazards/services/kyh.service.ts
@@ -48,14 +48,6 @@ export class KyhService {
     return this.kyhStore.state$.pipe(map((state) => state.currentPage));
   }
 
-  get currentHazard(): HazardType {
-    return this.kyhStore.state.currentHazard;
-  }
-
-  get currentHazard$(): Observable<HazardType> {
-    return this.kyhStore.state$.pipe(map((state) => state.currentHazard));
-  }
-
   get floodRiskLevel$(): Observable<RiskLevel> {
     return this.kyhStore.state$.pipe(map((state) => state.floodRiskLevel));
   }
@@ -147,17 +139,6 @@ export class KyhService {
         shown:
           currentPage === 'storm-surge' || currentPage === 'know-your-hazards',
       },
-    };
-
-    this.kyhStore.patch({ ...newHazardState }, 'show/hide hazards');
-  }
-
-  setCurrentHazard(currentHazard: HazardType) {
-    this.kyhStore.patch({ currentHazard }, 'update current hazard');
-    const newHazardState: Record<HazardType, { shown: boolean }> = {
-      flood: { shown: currentHazard === 'flood' },
-      landslide: { shown: currentHazard === 'landslide' },
-      'storm-surge': { shown: currentHazard === 'storm-surge' },
     };
 
     this.kyhStore.patch({ ...newHazardState }, 'show/hide hazards');

--- a/src/app/features/know-your-hazards/services/kyh.service.ts
+++ b/src/app/features/know-your-hazards/services/kyh.service.ts
@@ -112,12 +112,6 @@ export class KyhService {
     this.assessRisk();
   }
 
-  getHazardExposureLevel$(hazardType: HazardType): Observable<ExposureLevel> {
-    return this.kyhStore.state$.pipe(
-      map((state) => state[hazardType].exposureLevel)
-    );
-  }
-
   isHazardShown$(hazardType: HazardType): Observable<boolean> {
     return this.kyhStore.state$.pipe(map((state) => state[hazardType].shown));
   }
@@ -140,10 +134,33 @@ export class KyhService {
 
   setCurrentPage(currentPage: KYHPage): void {
     this.kyhStore.patch({ currentPage }, 'update current page');
+
+    const newHazardState: Record<HazardType, { shown: boolean }> = {
+      flood: {
+        shown: currentPage === 'flood' || currentPage === 'know-your-hazards',
+      },
+      landslide: {
+        shown:
+          currentPage === 'landslide' || currentPage === 'know-your-hazards',
+      },
+      'storm-surge': {
+        shown:
+          currentPage === 'storm-surge' || currentPage === 'know-your-hazards',
+      },
+    };
+
+    this.kyhStore.patch({ ...newHazardState }, 'show/hide hazards');
   }
 
   setCurrentHazard(currentHazard: HazardType) {
     this.kyhStore.patch({ currentHazard }, 'update current hazard');
+    const newHazardState: Record<HazardType, { shown: boolean }> = {
+      flood: { shown: currentHazard === 'flood' },
+      landslide: { shown: currentHazard === 'landslide' },
+      'storm-surge': { shown: currentHazard === 'storm-surge' },
+    };
+
+    this.kyhStore.patch({ ...newHazardState }, 'show/hide hazards');
   }
 
   setMapCenter(coords: { lat: number; lng: number }) {

--- a/src/app/features/know-your-hazards/store/kyh.store.ts
+++ b/src/app/features/know-your-hazards/store/kyh.store.ts
@@ -21,7 +21,6 @@ export type ExposureLevel =
 
 export type HazardState = {
   shown: boolean;
-  exposureLevel: ExposureLevel;
 };
 
 type KYHState = {
@@ -54,15 +53,12 @@ const createInitialValue = (): KYHState => {
 
     flood: {
       shown: true,
-      exposureLevel: 'unavailable',
     },
     landslide: {
       shown: true,
-      exposureLevel: 'unavailable',
     },
     'storm-surge': {
       shown: true,
-      exposureLevel: 'unavailable',
     },
   };
 };

--- a/src/app/features/know-your-hazards/store/kyh.store.ts
+++ b/src/app/features/know-your-hazards/store/kyh.store.ts
@@ -10,7 +10,19 @@ export type KYHPage = 'know-your-hazards' | 'critical-facilities' | HazardType;
 
 export type HazardType = 'flood' | 'landslide' | 'storm-surge';
 
+// Remove later -- replace with exposure level
 export type RiskLevel = 'unavailable' | 'little' | 'low' | 'medium' | 'high';
+export type ExposureLevel =
+  | 'unavailable'
+  | 'little'
+  | 'low'
+  | 'medium'
+  | 'high';
+
+export type HazardState = {
+  shown: boolean;
+  exposureLevel: ExposureLevel;
+};
 
 type KYHState = {
   isLoading: boolean;
@@ -22,6 +34,10 @@ type KYHState = {
   stormSurgeRiskLevel: RiskLevel;
   landslideRiskLevel: RiskLevel;
   currentLocation: string;
+
+  flood: HazardState;
+  landslide: HazardState;
+  'storm-surge': HazardState;
 };
 
 const createInitialValue = (): KYHState => {
@@ -35,6 +51,19 @@ const createInitialValue = (): KYHState => {
     stormSurgeRiskLevel: 'unavailable',
     landslideRiskLevel: 'unavailable',
     currentLocation: '',
+
+    flood: {
+      shown: true,
+      exposureLevel: 'unavailable',
+    },
+    landslide: {
+      shown: true,
+      exposureLevel: 'unavailable',
+    },
+    'storm-surge': {
+      shown: true,
+      exposureLevel: 'unavailable',
+    },
   };
 };
 

--- a/src/app/features/know-your-hazards/store/kyh.store.ts
+++ b/src/app/features/know-your-hazards/store/kyh.store.ts
@@ -28,7 +28,6 @@ type KYHState = {
   center: { lng: number; lat: number };
   currentCoords: { lng: number; lat: number };
   currentPage: KYHPage;
-  currentHazard: HazardType;
   floodRiskLevel: RiskLevel;
   stormSurgeRiskLevel: RiskLevel;
   landslideRiskLevel: RiskLevel;
@@ -45,7 +44,6 @@ const createInitialValue = (): KYHState => {
     center: PH_DEFAULT_CENTER,
     currentCoords: PH_DEFAULT_CENTER,
     currentPage: 'know-your-hazards',
-    currentHazard: 'flood',
     floodRiskLevel: 'unavailable',
     stormSurgeRiskLevel: 'unavailable',
     landslideRiskLevel: 'unavailable',

--- a/src/app/shared/data/kyh_combined_tileset.json
+++ b/src/app/shared/data/kyh_combined_tileset.json
@@ -1,6 +1,6 @@
 [
   {
-    "url": "mapbox://prince-test.ph_fh_100yr_tls",
+    "url": "mapbox://upri-noah.ph_fh_100yr_tls",
     "sourceLayer": [
       "PH010000000_FH_100yr",
       "PH020000000_FH_100yr",
@@ -22,7 +22,7 @@
     ]
   },
   {
-    "url": "mapbox://prince-test.ph_lh_lh1_tls",
+    "url": "mapbox://upri-noah.ph_lh_lh1_tls",
     "sourceLayer": [
       "PH010000000_LH_lh1",
       "PH020000000_LH_lh1",
@@ -44,7 +44,22 @@
     ]
   },
   {
-    "url": "mapbox://prince-test.ph_ssh_ssa4_tls",
+    "url": "mapbox://upri-noah.ph_lh_lh2_tls",
+    "sourceLayer": ["ph_lh_af", "ph_lh_df"]
+  },
+  {
+    "url": "mapbox://upri-noah.ph_lh_lh3_tls",
+    "sourceLayer": [
+      "PH010000000_LH_lh3",
+      "PH020000000_LH_lh3",
+      "PH030000000_LH_lh3",
+      "PH040000000_LH_lh3",
+      "PH090000000_LH_lh3",
+      "PH130000000_LH_lh3"
+    ]
+  },
+  {
+    "url": "mapbox://upri-noah.ph_ssh_ssa4_tls",
     "sourceLayer": [
       "PH010000000_SSH_ssa4",
       "PH020000000_SSH_ssa4",


### PR DESCRIPTION
# Summary

- Display debris flow, alluvial fan, and unstable slopes
- Only show the selected hazard type

**Note**
- There's a bit of a lag when upon zooming in and out
- Lots to refactor later on

# Demo

## Base 

![image](https://user-images.githubusercontent.com/11599005/135513124-7f0471b1-231e-4341-9f79-fe8be3b01e5e.png)

## Flood

![image](https://user-images.githubusercontent.com/11599005/135513076-f90a9500-1719-4771-a170-7c7872e5c8e1.png)


## Landslide

![image](https://user-images.githubusercontent.com/11599005/135513049-e2e9aee0-658f-4118-82e3-e3409c35ff4a.png)


## Storm Surge

![image](https://user-images.githubusercontent.com/11599005/135513152-30772ac5-b476-417e-8c7c-630a1a0b64eb.png)
