### PR TITLE
feat(know-your-hazards): dynamically load and display the nearest 20 critical facilities

### DIFF
--- a/src/app/features/know-your-hazards/components/critical-facilities-kyh/critical-facilities-kyh.component.ts
+++ b/src/app/features/know-your-hazards/components/critical-facilities-kyh/critical-facilities-kyh.component.ts
@@ -24,15 +24,9 @@ export class CriticalFacilitiesKyhComponent implements OnInit {
     this.currentLocation$ = this.kyhService.currentLocation$;
     this.kyhService.setCurrentPage('know-your-hazards');
 
-    this.kyhService.currentCoords$
-      .pipe(
-        switchMap((coords) => this.hazardService.getCriticalFacilities(coords)),
-        tap((c) => console.log(c)),
-        takeUntil(this._unsub)
-      )
-      .subscribe(
-        (criticalFacilities) => (this.criticalFacilities = criticalFacilities)
-      );
+    this.kyhService.criticalFacilities$.subscribe(
+      (criticalFacilities) => (this.criticalFacilities = criticalFacilities)
+    );
   }
 
   ngOnDestroy(): void {

--- a/src/app/features/know-your-hazards/components/critical-facilities-kyh/critical-facilities-kyh.component.ts
+++ b/src/app/features/know-your-hazards/components/critical-facilities-kyh/critical-facilities-kyh.component.ts
@@ -1,9 +1,13 @@
 import { Component, OnInit } from '@angular/core';
-import { HazardsService } from '@features/know-your-hazards/services/hazards.service';
+import {
+  CriticalFacilityFeature,
+  HazardsService,
+  MapItem,
+} from '@features/know-your-hazards/services/hazards.service';
 import { KyhService } from '@features/know-your-hazards/services/kyh.service';
 import { Observable, Subject } from 'rxjs';
 import { SampleMarker } from '@shared/mocks/critical-facilities';
-import { switchMap, takeUntil, tap } from 'rxjs/operators';
+import { map, switchMap, takeUntil, tap } from 'rxjs/operators';
 
 @Component({
   selector: 'noah-critical-facilities-kyh',
@@ -24,9 +28,17 @@ export class CriticalFacilitiesKyhComponent implements OnInit {
     this.currentLocation$ = this.kyhService.currentLocation$;
     this.kyhService.setCurrentPage('know-your-hazards');
 
-    this.kyhService.criticalFacilities$.subscribe(
-      (criticalFacilities) => (this.criticalFacilities = criticalFacilities)
-    );
+    this.kyhService.criticalFacilities$
+      .pipe(
+        map((featureCollection) =>
+          this._getCriticalFacility(
+            featureCollection.features as CriticalFacilityFeature[]
+          )
+        )
+      )
+      .subscribe(
+        (criticalFacilities) => (this.criticalFacilities = criticalFacilities)
+      );
   }
 
   ngOnDestroy(): void {
@@ -39,6 +51,32 @@ export class CriticalFacilitiesKyhComponent implements OnInit {
       lat: (<[number, number]>marker.coords)[1],
       lng: (<[number, number]>marker.coords)[0],
     };
-    this.kyhService.setCenter(coords);
+    this.kyhService.setCurrentCoords(coords);
+  }
+
+  private _getCriticalFacility(
+    featureList: CriticalFacilityFeature[]
+  ): MapItem[] {
+    const getType = (layerName: string) => {
+      switch (layerName) {
+        case 'fire_station':
+          return 'fire-station';
+        case 'hospitals':
+          return 'hospital';
+        case 'police_station':
+          return 'police-station';
+        case 'schools':
+          return 'school';
+        default:
+          throw new Error('critical facility layer not found!');
+      }
+    };
+
+    return featureList.map((feature) => ({
+      coords: feature.geometry.coordinates,
+      name: feature.properties.name,
+      type: getType(feature.properties.tilequery.layer),
+      distance: feature.properties.tilequery.distance / 1000, // to km
+    }));
   }
 }

--- a/src/app/features/know-your-hazards/components/critical-facilities-kyh/critical-facilities-kyh.component.ts
+++ b/src/app/features/know-your-hazards/components/critical-facilities-kyh/critical-facilities-kyh.component.ts
@@ -3,7 +3,7 @@ import { HazardsService } from '@features/know-your-hazards/services/hazards.ser
 import { KyhService } from '@features/know-your-hazards/services/kyh.service';
 import { Observable, Subject } from 'rxjs';
 import { SampleMarker } from '@shared/mocks/critical-facilities';
-import { switchMap, takeUntil } from 'rxjs/operators';
+import { switchMap, takeUntil, tap } from 'rxjs/operators';
 
 @Component({
   selector: 'noah-critical-facilities-kyh',
@@ -27,6 +27,7 @@ export class CriticalFacilitiesKyhComponent implements OnInit {
     this.kyhService.currentCoords$
       .pipe(
         switchMap((coords) => this.hazardService.getCriticalFacilities(coords)),
+        tap((c) => console.log(c)),
         takeUntil(this._unsub)
       )
       .subscribe(

--- a/src/app/features/know-your-hazards/services/hazards.service.ts
+++ b/src/app/features/know-your-hazards/services/hazards.service.ts
@@ -34,7 +34,7 @@ type CriticalFacilityFeature = Feature & {
   };
 };
 
-type MapItem = {
+export type MapItem = {
   coords: LngLatLike;
   name: string;
   type: string;

--- a/src/app/features/know-your-hazards/services/hazards.service.ts
+++ b/src/app/features/know-your-hazards/services/hazards.service.ts
@@ -19,7 +19,7 @@ type AssessmentPayload = {
   tilesetName: string;
 };
 
-type CriticalFacilityFeature = Feature & {
+export type CriticalFacilityFeature = Feature & {
   geometry: {
     coordinates: [number, number];
   };
@@ -68,14 +68,7 @@ export class HazardsService {
         'upri-noah.schools_tls,upri-noah.hospitals_tls,upri-noah.fire_station_tls,upri-noah.police_station_tls',
     };
 
-    return this.getFeatureInfo(payload).pipe(
-      map((featureCollection) =>
-        this._getCriticalFacility(
-          featureCollection.features as CriticalFacilityFeature[]
-        )
-      ),
-      take(1)
-    );
+    return this.getFeatureInfo(payload).pipe(take(1));
   }
 
   getFeatureInfo(
@@ -90,10 +83,9 @@ export class HazardsService {
         'pk.eyJ1IjoidXByaS1ub2FoIiwiYSI6ImNrcmExaDdydzRldWYyb21udmw1ejY3ZDYifQ.cs3Ahz2S6fERoI1BAwFO9g'
       );
 
-    return this.http.get<FeatureCollection>(baseURL, { params }).pipe(
-      tap((result) => console.log(result)),
-      catchError(this.handleError('getFeatureInfo', null))
-    );
+    return this.http
+      .get<FeatureCollection>(baseURL, { params })
+      .pipe(catchError(this.handleError('getFeatureInfo', null)));
   }
 
   private _getRiskLevel(feature: FeatureCollection | null): RiskLevel {

--- a/src/app/features/know-your-hazards/services/hazards.service.ts
+++ b/src/app/features/know-your-hazards/services/hazards.service.ts
@@ -64,7 +64,8 @@ export class HazardsService {
       coords,
       limit: 25,
       radius: 5000, // 5km
-      tilesetName: CF_TILESET_NAMES,
+      tilesetName:
+        'upri-noah.schools_tls,upri-noah.hospitals_tls,upri-noah.fire_station_tls,upri-noah.police_station_tls',
     };
 
     return this.getFeatureInfo(payload).pipe(
@@ -84,7 +85,10 @@ export class HazardsService {
     const params = new HttpParams()
       .set('radius', payload.radius ? String(payload.radius) : '50')
       .set('limit', payload.limit ? String(payload.limit) : '20')
-      .set('access_token', environment.mapbox.accessToken);
+      .set(
+        'access_token',
+        'pk.eyJ1IjoidXByaS1ub2FoIiwiYSI6ImNrcmExaDdydzRldWYyb21udmw1ejY3ZDYifQ.cs3Ahz2S6fERoI1BAwFO9g'
+      );
 
     return this.http.get<FeatureCollection>(baseURL, { params }).pipe(
       tap((result) => console.log(result)),
@@ -103,15 +107,15 @@ export class HazardsService {
   private _getCriticalFacility(
     featureList: CriticalFacilityFeature[]
   ): MapItem[] {
-    const getType = (layerName: CriticalFacilityLayer) => {
+    const getType = (layerName: string) => {
       switch (layerName) {
-        case 'leyte_firestation':
+        case 'fire_station':
           return 'fire-station';
-        case 'leyte_hospitals':
+        case 'hospitals':
           return 'hospital';
-        case 'leyte_police':
+        case 'police_station':
           return 'police-station';
-        case 'leyte_schools':
+        case 'schools':
           return 'school';
         default:
           throw new Error('critical facility layer not found!');

--- a/src/app/features/know-your-hazards/services/kyh.service.ts
+++ b/src/app/features/know-your-hazards/services/kyh.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
 import { Observable, Subject } from 'rxjs';
-import { map } from 'rxjs/operators';
+import { map, shareReplay, switchMap } from 'rxjs/operators';
 import {
   HazardType,
   KyhStore,
@@ -9,7 +9,7 @@ import {
   PH_DEFAULT_CENTER,
   ExposureLevel,
 } from '../store/kyh.store';
-import { HazardsService } from './hazards.service';
+import { HazardsService, MapItem } from './hazards.service';
 
 @Injectable({
   providedIn: 'root',
@@ -26,6 +26,13 @@ export class KyhService {
   }
   get center$(): Observable<{ lng: number; lat: number }> {
     return this.kyhStore.state$.pipe(map((state) => state.center));
+  }
+
+  get criticalFacilities$(): Observable<MapItem[]> {
+    return this.currentCoords$.pipe(
+      switchMap((coords) => this.hazardsService.getCriticalFacilities(coords)),
+      shareReplay(1)
+    );
   }
 
   get currentCoords$(): Observable<{ lng: number; lat: number }> {

--- a/src/app/features/know-your-hazards/services/kyh.service.ts
+++ b/src/app/features/know-your-hazards/services/kyh.service.ts
@@ -1,6 +1,12 @@
 import { Injectable } from '@angular/core';
+import { FeatureCollection } from 'geojson';
 import { Observable, Subject } from 'rxjs';
-import { map, shareReplay, switchMap } from 'rxjs/operators';
+import {
+  distinctUntilChanged,
+  map,
+  shareReplay,
+  switchMap,
+} from 'rxjs/operators';
 import {
   HazardType,
   KyhStore,
@@ -9,7 +15,11 @@ import {
   PH_DEFAULT_CENTER,
   ExposureLevel,
 } from '../store/kyh.store';
-import { HazardsService, MapItem } from './hazards.service';
+import {
+  CriticalFacilityFeature,
+  HazardsService,
+  MapItem,
+} from './hazards.service';
 
 @Injectable({
   providedIn: 'root',
@@ -25,18 +35,25 @@ export class KyhService {
     this.keyBoard.next(message);
   }
   get center$(): Observable<{ lng: number; lat: number }> {
-    return this.kyhStore.state$.pipe(map((state) => state.center));
+    return this.kyhStore.state$.pipe(
+      map((state) => state.center),
+      shareReplay(1)
+    );
   }
 
-  get criticalFacilities$(): Observable<MapItem[]> {
-    return this.currentCoords$.pipe(
+  get criticalFacilities$(): Observable<FeatureCollection> {
+    return this.center$.pipe(
+      distinctUntilChanged(),
       switchMap((coords) => this.hazardsService.getCriticalFacilities(coords)),
       shareReplay(1)
     );
   }
 
   get currentCoords$(): Observable<{ lng: number; lat: number }> {
-    return this.kyhStore.state$.pipe(map((state) => state.currentCoords));
+    return this.kyhStore.state$.pipe(
+      map((state) => state.currentCoords),
+      shareReplay(1)
+    );
   }
 
   get currentCoords(): { lng: number; lat: number } {

--- a/src/app/shared/mocks/critical-facilities.ts
+++ b/src/app/shared/mocks/critical-facilities.ts
@@ -199,3 +199,22 @@ export const MAPBOX_CRIT_FAC = {
     sourceLayer: 'police_station_g-6ekisg',
   },
 };
+
+// export const MAPBOX_CRIT_FAC = {
+//   school: {
+//     url: 'mapbox://upri-noah.schools_tls',
+//     sourceLayer: 'schools',
+//   },
+//   hospital: {
+//     url: 'mapbox://upri-noah.hospitals_tls',
+//     sourceLayer: 'hospitals_tls',
+//   },
+//   'fire-station': {
+//     url: 'mapbox://upri-noah.fire_station_tls',
+//     sourceLayer: 'fire_station',
+//   },
+//   'police-station': {
+//     url: 'mapbox://upri-noah.police_station_tls',
+//     sourceLayer: 'police_station',
+//   },
+// };


### PR DESCRIPTION
# Summary

When the user enters their location in the map, the nearest 20 critical facilities are displayed in the side panel. The same list is loaded in the map. When the user clicks on a critical facility in the side panel list, the map centers at the coordinates of the selected facility.

Only the critical facilities displayed in the side panel gets displayed in the map. This means the critical facilities displayed in the map varies according to the location of the user. ✨ 

# Demo

![Kapture 2021-10-01 at 04 50 42](https://user-images.githubusercontent.com/11599005/135528497-5f30a9c7-67b3-4d64-bd79-e9a6ed18aca4.gif)

