### PR TITLE
fix(playground): default visibility settings of the hazard maps

### DIFF
--- a/src/app/features/noah-playground/store/noah-playground.store.ts
+++ b/src/app/features/noah-playground/store/noah-playground.store.ts
@@ -143,7 +143,7 @@ const createInitialValue = (): NoahPlaygroundState => ({
     },
   },
   landslide: {
-    shown: true,
+    shown: false,
     expanded: false,
     levels: {
       'landslide-hazard': {
@@ -169,7 +169,7 @@ const createInitialValue = (): NoahPlaygroundState => ({
     },
   },
   'storm-surge': {
-    shown: true,
+    shown: false,
     expanded: false,
     levels: {
       'storm-surge-advisory-1': {

--- a/src/app/features/noah-playground/store/noah-playground.store.ts
+++ b/src/app/features/noah-playground/store/noah-playground.store.ts
@@ -133,12 +133,12 @@ const createInitialValue = (): NoahPlaygroundState => ({
       'flood-return-period-25': {
         opacity: 85,
         color: 'noah-red',
-        shown: true,
+        shown: false,
       },
       'flood-return-period-100': {
         opacity: 85,
         color: 'noah-red',
-        shown: false,
+        shown: true,
       },
     },
   },


### PR DESCRIPTION
# Summary

Update default settings on load:
  - Show 100-year rain return
  - Hide landslides
  - Hide storm surges

![image](https://user-images.githubusercontent.com/11599005/135745389-03020b66-0d81-4bff-9ca4-bdd00d99cf85.png)
