### PR TITLE
feat: changing mapbox attribution

### DIFF
--- a/src/app/features/know-your-hazards/components/map-kyh/map-kyh.component.html
+++ b/src/app/features/know-your-hazards/components/map-kyh/map-kyh.component.html
@@ -5,7 +5,22 @@
     <div class="switch">
       <div class="dropdown inline-block relative">
         <button
-          class="bg-white text-gray-800 font-semibold py-1 px-1 ml-2 rounded inline-flex items-center hover:bg-gray-200 focus:outline-none focus:ring-2 focus:ring-gray-600 focus:ring-opacity-50"
+          class="
+            bg-white
+            text-gray-800
+            font-semibold
+            py-1
+            px-1
+            ml-2
+            rounded
+            inline-flex
+            items-center
+            hover:bg-gray-200
+            focus:outline-none
+            focus:ring-2
+            focus:ring-gray-600
+            focus:ring-opacity-50
+          "
         >
           <svg
             (click)="isOpenedList = 0"
@@ -60,12 +75,35 @@
         </button>
 
         <ul
-          class="dropdown-menu rounded-lg shadow-2xl drop-shadow-xl bg-white right-9 bottom-0 absolute text-sm text-gray-700"
+          class="
+            dropdown-menu
+            rounded-lg
+            shadow-2xl
+            drop-shadow-xl
+            bg-white
+            right-9
+            bottom-0
+            absolute
+            text-sm text-gray-700
+          "
           *ngIf="isOpenedList === 2"
         >
           <li class="">
             <a
-              class="rounded-lg block px-4 py-2 text-sm leading-5 text-gray-700 transition duration-150 ease-in-out hover:bg-gray-100 focus:outline-none focus:bg-gray-100"
+              class="
+                rounded-lg
+                block
+                px-4
+                py-2
+                text-sm
+                leading-5
+                text-gray-700
+                transition
+                duration-150
+                ease-in-out
+                hover:bg-gray-100
+                focus:outline-none focus:bg-gray-100
+              "
               role="button"
               (click)="switchMapStyle('terrain')"
               >Terrain</a
@@ -73,7 +111,20 @@
           </li>
           <li class="">
             <a
-              class="rounded-lg block px-4 py-2 text-sm leading-5 text-gray-700 transition duration-150 ease-in-out hover:bg-gray-100 focus:outline-none focus:bg-gray-100"
+              class="
+                rounded-lg
+                block
+                px-4
+                py-2
+                text-sm
+                leading-5
+                text-gray-700
+                transition
+                duration-150
+                ease-in-out
+                hover:bg-gray-100
+                focus:outline-none focus:bg-gray-100
+              "
               role="button"
               (click)="switchMapStyle('satellite')"
               >Satellite</a
@@ -83,4 +134,53 @@
       </div>
     </div>
   </a>
+</div>
+<!-- //Customizing Mapbox attribution -->
+<div class="mapboxgl-ctrl-bottom-right hidden md:block">
+  <div class="mapboxgl-ctrl mapboxgl-ctrl-attrib">
+    <button
+      class="mapboxgl-ctrl-attrib-button"
+      type="button"
+      title="Toggle attribution"
+      aria-label="Toggle attribution"
+    ></button>
+    <div class="mapboxgl-ctrl-attrib-inner text-black" role="list">
+      <a
+        href="https://www.mapbox.com/about/maps/"
+        target="_blank"
+        title="Mapbox"
+        class="mr-1 text-black"
+        aria-label="Mapbox"
+        role="listitem"
+        >© Mapbox</a
+      >
+      <a
+        href="http://www.openstreetmap.org/about/"
+        target="_blank"
+        title="OpenStreetMap"
+        class="mr-1 text-black"
+        aria-label="OpenStreetMap"
+        role="listitem"
+        >© OpenStreetMap</a
+      >
+      <a
+        href="https://doh.gov.ph/"
+        target="_blank"
+        title="OpenStreetMap"
+        aria-label="DOH"
+        class="mr-1 text-black"
+        role="listitem"
+        >© Department of Health</a
+      >
+      <a
+        href="https://www.mapbox.com/map-feedback/"
+        target="_blank"
+        title="Improve this map"
+        class="text-black"
+        aria-label="Improve this map"
+        role="listitem"
+        >Improve this map
+      </a>
+    </div>
+  </div>
 </div>

--- a/src/app/features/know-your-hazards/components/map-kyh/map-kyh.component.ts
+++ b/src/app/features/know-your-hazards/components/map-kyh/map-kyh.component.ts
@@ -41,6 +41,7 @@ export class MapKyhComponent implements OnInit {
   geolocateControl!: GeolocateControl;
   centerMarker!: Marker;
   mapStyle: MapStyle = 'terrain';
+  isMapboxAttrib;
   isOpenedList;
   private _unsub = new Subject();
 
@@ -238,6 +239,7 @@ export class MapKyhComponent implements OnInit {
       touchZoomRotate: true,
       bearing: 30,
       center: this.kyhService.currentCoords,
+      attributionControl: false,
     });
   }
 

--- a/src/app/features/know-your-hazards/pages/know-your-hazards/know-your-hazards.component.html
+++ b/src/app/features/know-your-hazards/pages/know-your-hazards/know-your-hazards.component.html
@@ -14,7 +14,7 @@
     class="
       fixed
       p-2
-      z-20
+      z-50
       bg-white
       text-gray-800
       shadow-2xl
@@ -59,6 +59,7 @@
       w-2/3
     "
   ></noah-search>
+
   <nav
     class="
       block
@@ -124,36 +125,55 @@
                     aria-label="Toggle attribution"
                   ></div>
                   <div class="absolute z-40 right-0 -bottom-1 pt-2">
-                    <div class="rounded-lg bg-white w-72 mt-4">
+                    <div class="rounded-lg bg-white h-auto w-64 mt-4">
                       <ul *ngIf="isList === 1">
-                        <li class="p-1 text-xs flex">
-                          <a
-                            href="https://www.mapbox.com/about/maps/"
-                            target="_blank"
-                            title="Mapbox"
-                            aria-label="Mapbox"
-                            role="listitem"
-                          >
-                            <div class="mr-1 font-mono">© Mapbox</div></a
-                          >
-                          <a
-                            href="http://www.openstreetmap.org/about/"
-                            target="_blank"
-                            title="OpenStreetMap"
-                            aria-label="OpenStreetMap"
-                            role="listitem"
-                          >
-                            <div class="mr-1 font-mono">© OpenStreetMap</div></a
-                          >
-                          <a
-                            href="https://www.mapbox.com/map-feedback/"
-                            target="_blank"
-                            title="Improve this map"
-                            aria-label="Improve this map"
-                            role="listitem"
-                          >
-                            <div class="font-mono">Improve this map</div></a
-                          >
+                        <li class="p-1 text-xs">
+                          <div>
+                            <a
+                              href="https://www.mapbox.com/about/maps/"
+                              target="_blank"
+                              title="Mapbox"
+                              aria-label="Mapbox"
+                              role="listitem"
+                            >
+                              <span class="mr-1 text-black">© Mapbox</span></a
+                            >
+                            <a
+                              href="http://www.openstreetmap.org/about/"
+                              target="_blank"
+                              title="OpenStreetMap"
+                              aria-label="OpenStreetMap"
+                              role="listitem"
+                            >
+                              <span class="mr-1 text-black"
+                                >© OpenStreetMap</span
+                              >
+                            </a>
+                          </div>
+                          <div>
+                            <a
+                              href="https://doh.gov.ph/"
+                              target="_blank"
+                              title="Mapbox"
+                              aria-label="Mapbox"
+                              role="listitem"
+                            >
+                              <span class="mr-1 text-black"
+                                >© Department of Health</span
+                              ></a
+                            >
+                            <a
+                              href="https://www.mapbox.com/map-feedback/"
+                              target="_blank"
+                              title="OpenStreetMap"
+                              aria-label="OpenStreetMap"
+                              role="listitem"
+                            >
+                              <span class="mr-1 text-black"
+                                >Improve this map</span
+                              >
+                            </a>
+                          </div>
                         </li>
                       </ul>
                     </div>
@@ -164,6 +184,7 @@
           </a>
         </div>
       </div>
+
       <!-- MAPBOX LOGOS -->
       <div (click)="isMenu = !isMenu" class="text-black ml-8 cursor-pointer">
         <button
@@ -370,6 +391,78 @@
       </div>
     </ng-container>
   </nav>
+  <!-- //Customizing Mapbox attribution -->
+  <div class="mapboxgl-ctrl-bottom-right md:hidden z-40">
+    <div class="mapboxgl-ctrl mapboxgl-ctrl-attrib mapboxgl-compact">
+      <div
+        class="cursor-pointer"
+        (click)="isList === 1 ? (isList = 0) : (isList = 1)"
+      >
+        <div
+          class="
+            mapboxgl-ctrl-attrib-button
+            bg-gray-200
+            z-50
+            focus:outline-none
+          "
+          type="button"
+          title="Toggle attribution"
+          aria-label="Toggle attribution"
+        ></div>
+        <div class="absolute z-40 right-0 -bottom-1 pt-2">
+          <div class="rounded-lg bg-white h-auto w-64 mt-4">
+            <ul *ngIf="isList === 1">
+              <li class="p-1 text-xs">
+                <div>
+                  <a
+                    href="https://www.mapbox.com/about/maps/"
+                    target="_blank"
+                    title="Mapbox"
+                    aria-label="Mapbox"
+                    role="listitem"
+                  >
+                    <span class="mr-1 text-black">© Mapbox</span></a
+                  >
+                  <a
+                    href="http://www.openstreetmap.org/about/"
+                    target="_blank"
+                    title="OpenStreetMap"
+                    aria-label="OpenStreetMap"
+                    role="listitem"
+                  >
+                    <span class="mr-1 text-black">© OpenStreetMap</span>
+                  </a>
+                </div>
+                <div>
+                  <a
+                    href="https://doh.gov.ph/"
+                    target="_blank"
+                    title="Mapbox"
+                    aria-label="Mapbox"
+                    role="listitem"
+                  >
+                    <span class="mr-1 text-black"
+                      >© Department of Health</span
+                    ></a
+                  >
+                  <a
+                    href="https://www.mapbox.com/map-feedback/"
+                    target="_blank"
+                    title="OpenStreetMap"
+                    aria-label="OpenStreetMap"
+                    role="listitem"
+                  >
+                    <span class="mr-1 text-black">Improve this map</span>
+                  </a>
+                </div>
+              </li>
+            </ul>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <!-- //Customizing Mapbox attribution -->
   <!-- MOBILE VIEW -->
 
   <!-- DESKTOP VIEW -->

--- a/src/app/features/noah-playground/components/map-playground/map-playground.component.html
+++ b/src/app/features/noah-playground/components/map-playground/map-playground.component.html
@@ -108,3 +108,53 @@
     </div>
   </div>
 </div>
+
+<!-- //Customizing Mapbox attribution -->
+<div class="mapboxgl-ctrl-bottom-right hidden md:block">
+  <div class="mapboxgl-ctrl mapboxgl-ctrl-attrib">
+    <button
+      class="mapboxgl-ctrl-attrib-button"
+      type="button"
+      title="Toggle attribution"
+      aria-label="Toggle attribution"
+    ></button>
+    <div class="mapboxgl-ctrl-attrib-inner text-black" role="list">
+      <a
+        href="https://www.mapbox.com/about/maps/"
+        target="_blank"
+        title="Mapbox"
+        class="mr-1 text-black"
+        aria-label="Mapbox"
+        role="listitem"
+        >© Mapbox</a
+      >
+      <a
+        href="http://www.openstreetmap.org/about/"
+        target="_blank"
+        title="OpenStreetMap"
+        class="mr-1 text-black"
+        aria-label="OpenStreetMap"
+        role="listitem"
+        >© OpenStreetMap</a
+      >
+      <a
+        href="https://doh.gov.ph/"
+        target="_blank"
+        title="OpenStreetMap"
+        aria-label="DOH"
+        class="mr-1 text-black"
+        role="listitem"
+        >© Department of Health</a
+      >
+      <a
+        href="https://www.mapbox.com/map-feedback/"
+        target="_blank"
+        title="Improve this map"
+        class="text-black"
+        aria-label="Improve this map"
+        role="listitem"
+        >Improve this map
+      </a>
+    </div>
+  </div>
+</div>

--- a/src/app/features/noah-playground/components/map-playground/map-playground.component.ts
+++ b/src/app/features/noah-playground/components/map-playground/map-playground.component.ts
@@ -86,6 +86,7 @@ export class MapPlaygroundComponent implements OnInit, OnDestroy {
   centerMarker!: Marker;
   pgLocation: string = '';
   mapStyle: MapStyle = 'terrain';
+  isMapboxAttrib;
 
   private _graphShown = false;
   private _unsub = new Subject();
@@ -456,6 +457,7 @@ export class MapPlaygroundComponent implements OnInit, OnDestroy {
       zoom: 5,
       touchZoomRotate: true,
       center: PH_DEFAULT_CENTER,
+      attributionControl: false,
     });
   }
 

--- a/src/app/features/noah-playground/pages/noah-playground/noah-playground.component.html
+++ b/src/app/features/noah-playground/pages/noah-playground/noah-playground.component.html
@@ -4,7 +4,7 @@
     class="
       fixed
       p-2
-      z-20
+      z-50
       bg-white
       text-gray-800
       shadow-2xl
@@ -125,36 +125,53 @@
                   aria-label="Toggle attribution"
                 ></div>
                 <div class="absolute z-40 right-0 -bottom-1 pt-2">
-                  <div class="rounded-lg bg-white w-72 mt-4">
+                  <div class="rounded-lg bg-white h-auto w-64 mt-4">
                     <ul *ngIf="isList === 1">
-                      <li class="p-1 text-xs flex">
-                        <a
-                          href="https://www.mapbox.com/about/maps/"
-                          target="_blank"
-                          title="Mapbox"
-                          aria-label="Mapbox"
-                          role="listitem"
-                        >
-                          <div class="mr-1 font-mono">© Mapbox</div></a
-                        >
-                        <a
-                          href="http://www.openstreetmap.org/about/"
-                          target="_blank"
-                          title="OpenStreetMap"
-                          aria-label="OpenStreetMap"
-                          role="listitem"
-                        >
-                          <div class="mr-1 font-mono">© OpenStreetMap</div></a
-                        >
-                        <a
-                          href="https://www.mapbox.com/map-feedback/"
-                          target="_blank"
-                          title="Improve this map"
-                          aria-label="Improve this map"
-                          role="listitem"
-                        >
-                          <div class="font-mono">Improve this map</div></a
-                        >
+                      <li class="p-1 text-xs">
+                        <div>
+                          <a
+                            href="https://www.mapbox.com/about/maps/"
+                            target="_blank"
+                            title="Mapbox"
+                            aria-label="Mapbox"
+                            role="listitem"
+                          >
+                            <span class="mr-1 text-black">© Mapbox</span></a
+                          >
+                          <a
+                            href="http://www.openstreetmap.org/about/"
+                            target="_blank"
+                            title="OpenStreetMap"
+                            aria-label="OpenStreetMap"
+                            role="listitem"
+                          >
+                            <span class="mr-1 text-black">© OpenStreetMap</span>
+                          </a>
+                        </div>
+                        <div>
+                          <a
+                            href="https://doh.gov.ph/"
+                            target="_blank"
+                            title="Mapbox"
+                            aria-label="Mapbox"
+                            role="listitem"
+                          >
+                            <span class="mr-1 text-black"
+                              >© Department of Health</span
+                            ></a
+                          >
+                          <a
+                            href="https://www.mapbox.com/map-feedback/"
+                            target="_blank"
+                            title="OpenStreetMap"
+                            aria-label="OpenStreetMap"
+                            role="listitem"
+                          >
+                            <span class="mr-1 text-black"
+                              >Improve this map</span
+                            >
+                          </a>
+                        </div>
                       </li>
                     </ul>
                   </div>
@@ -291,6 +308,78 @@
       <noah-sensors-group></noah-sensors-group>
     </div>
   </nav>
+  <!-- //Customizing Mapbox attribution -->
+  <div class="mapboxgl-ctrl-bottom-right md:hidden z-40">
+    <div class="mapboxgl-ctrl mapboxgl-ctrl-attrib mapboxgl-compact">
+      <div
+        class="cursor-pointer"
+        (click)="isList === 1 ? (isList = 0) : (isList = 1)"
+      >
+        <div
+          class="
+            mapboxgl-ctrl-attrib-button
+            bg-gray-200
+            z-50
+            focus:outline-none
+          "
+          type="button"
+          title="Toggle attribution"
+          aria-label="Toggle attribution"
+        ></div>
+        <div class="absolute z-40 right-0 -bottom-1 pt-2">
+          <div class="rounded-lg bg-white h-auto w-64 mt-4">
+            <ul *ngIf="isList === 1">
+              <li class="p-1 text-xs">
+                <div>
+                  <a
+                    href="https://www.mapbox.com/about/maps/"
+                    target="_blank"
+                    title="Mapbox"
+                    aria-label="Mapbox"
+                    role="listitem"
+                  >
+                    <span class="mr-1 text-black">© Mapbox</span></a
+                  >
+                  <a
+                    href="http://www.openstreetmap.org/about/"
+                    target="_blank"
+                    title="OpenStreetMap"
+                    aria-label="OpenStreetMap"
+                    role="listitem"
+                  >
+                    <span class="mr-1 text-black">© OpenStreetMap</span>
+                  </a>
+                </div>
+                <div>
+                  <a
+                    href="https://doh.gov.ph/"
+                    target="_blank"
+                    title="Mapbox"
+                    aria-label="Mapbox"
+                    role="listitem"
+                  >
+                    <span class="mr-1 text-black"
+                      >© Department of Health</span
+                    ></a
+                  >
+                  <a
+                    href="https://www.mapbox.com/map-feedback/"
+                    target="_blank"
+                    title="OpenStreetMap"
+                    aria-label="OpenStreetMap"
+                    role="listitem"
+                  >
+                    <span class="mr-1 text-black">Improve this map</span>
+                  </a>
+                </div>
+              </li>
+            </ul>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <!-- //Customizing Mapbox attribution -->
 
   <main class="block w-full md:w-3/4 bg-gray-100 order-1 md:min-h-screen z-10">
     <noah-map-playground></noah-map-playground>


### PR DESCRIPTION
# Description
- Changing mapbox attribution for playground and kyh map
- customize attribution and added "Department of Health"

- Added code in `map-playground.component.ts` and `map-kyh.component.ts`
- I created that code for me to customize the attribution and created new one per html file
> in `map-kyh.component.ts` line 237, added `attributionControl: false,`
![image](https://user-images.githubusercontent.com/62271587/135759281-b505f7cd-19c2-4cfb-a43a-74d52a4a3fda.png)

> in `map-playground.component.ts` line 300, added `attributionControl: false,`
![image](https://user-images.githubusercontent.com/62271587/135759256-b91e6e84-7e3b-42bd-ab30-b002a7468c36.png)
 


# Screenshot for mobile view attribution
![image](https://user-images.githubusercontent.com/62271587/135759084-26bc6389-841e-4c8d-a249-7f6ab8693e48.png)

# Screenshot for desktop view
![image](https://user-images.githubusercontent.com/62271587/135784225-a4b18ba0-e443-4d9a-82aa-55700883f925.png)

![image](https://user-images.githubusercontent.com/62271587/135784273-db5f96b1-3624-4989-85a3-55d4ffc42c26.png)
 

# Loom
https://www.loom.com/share/7be06c5c1ae54cd29f1a650da82db2e0

# Find bug
- In landing page the `Noah Playground` button