### PR TITLE
fix(studio): zoom in on ios

### DIFF
--- a/src/app/features/noah-playground/components/map-playground/map-playground.component.ts
+++ b/src/app/features/noah-playground/components/map-playground/map-playground.component.ts
@@ -102,8 +102,8 @@ export class MapPlaygroundComponent implements OnInit, OnDestroy {
   ngOnInit(): void {
     this.initMap();
 
-    fromEvent(this.map, 'load')
-      .pipe(takeUntil(this._unsub))
+    fromEvent(this.map, 'style.load')
+      .pipe(first(), takeUntil(this._unsub))
       .subscribe(() => {
         this.addNavigationControls();
         this.addGeolocationControls();


### PR DESCRIPTION
# Summary 

- Fixes https://github.com/UPRI-NOAH/noah-frontend/issues/186
- The `load` event isn't firing on NOAH Studio. As such, the `centerListener()` method isn't called which is responsible for the zooming in to the selected place. However, `style.load` do get called. The fix implemented here is to also use the event `style.load` to call the methods that were previously called by upon the firing of the `load` event but only listen to `style.load` once.
  - We need to further investigate **why** `load` doesn't work on Studio in iOS but works in KYH
- Confirming that only the NOAH Studio is affected by this issue.
 
# Demo

![Kapture 2021-10-05 at 22 49 45](https://user-images.githubusercontent.com/11599005/136047077-d0da7a85-9157-4d01-bae9-07a6039fd9c1.gif)
