### PR TITLE
fix(studio): sensors - visually display fetch data errors

### DIFF
--- a/src/app/features/noah-playground/components/map-playground/map-playground.component.ts
+++ b/src/app/features/noah-playground/components/map-playground/map-playground.component.ts
@@ -244,7 +244,12 @@ export class MapPlaygroundComponent implements OnInit, OnDestroy {
 
           // show mouse event listeners
           this.showDataPoints(sensorType);
-        });
+        })
+        .catch(() =>
+          console.error(
+            `Unable to fetch data from DOST for sensors of type "${sensorType}"`
+          )
+        );
     });
   }
 

--- a/src/app/features/noah-playground/components/map-playground/map-playground.component.ts
+++ b/src/app/features/noah-playground/components/map-playground/map-playground.component.ts
@@ -242,6 +242,7 @@ export class MapPlaygroundComponent implements OnInit, OnDestroy {
               );
             });
 
+          this.pgService.setSensorTypeFetched(sensorType, true);
           // show mouse event listeners
           this.showDataPoints(sensorType);
         })

--- a/src/app/features/noah-playground/components/sensor-solo/sensor-solo.component.html
+++ b/src/app/features/noah-playground/components/sensor-solo/sensor-solo.component.html
@@ -3,19 +3,25 @@
     <div class="flex items-center">
       <label class="inline-flex items-center checkbox {{ sensorType }}">
         <input
-          [checked]="shown$ | async"
+          [checked]="(shown$ | async) && !fetchFailed"
+          [disabled]="fetchFailed"
           (click)="toggleShown()"
           type="checkbox"
           class="h-5 w-5 text-blue-600"
         />
       </label>
       <div class="ml-3">
-        <div class="">{{ sensorName }}</div>
+        <div [class.line-through]="fetchFailed" class="text-gray-400">
+          {{ sensorName }}
+        </div>
       </div>
     </div>
   </div>
 
-  <div class="absolute left-0 bottom-0 text-xs italic pl-16 ml-2">
-    Unable to fetch data
+  <div
+    class="absolute left-0 bottom-0 text-xs italic pl-16 ml-2 text-gray-400"
+    *ngIf="fetchFailed"
+  >
+    (Unable to fetch data)
   </div>
 </div>

--- a/src/app/features/noah-playground/components/sensor-solo/sensor-solo.component.html
+++ b/src/app/features/noah-playground/components/sensor-solo/sensor-solo.component.html
@@ -1,15 +1,21 @@
-<div class="text-m f-f-r py-2 pl-4">
-  <div class="flex items-center">
-    <label class="inline-flex items-center checkbox {{ sensorType }}">
-      <input
-        [checked]="shown$ | async"
-        (click)="toggleShown()"
-        type="checkbox"
-        class="h-5 w-5 text-blue-600"
-      />
-    </label>
-    <div class="ml-3">
-      <div class="">{{ sensorName }}</div>
+<div class="pl-6 relative pb-2">
+  <div class="text-m f-f-r py-2 pl-4">
+    <div class="flex items-center">
+      <label class="inline-flex items-center checkbox {{ sensorType }}">
+        <input
+          [checked]="shown$ | async"
+          (click)="toggleShown()"
+          type="checkbox"
+          class="h-5 w-5 text-blue-600"
+        />
+      </label>
+      <div class="ml-3">
+        <div class="">{{ sensorName }}</div>
+      </div>
     </div>
+  </div>
+
+  <div class="absolute left-0 bottom-0 text-xs italic pl-16 ml-2">
+    Unable to fetch data
   </div>
 </div>

--- a/src/app/features/noah-playground/components/sensor-solo/sensor-solo.component.html
+++ b/src/app/features/noah-playground/components/sensor-solo/sensor-solo.component.html
@@ -1,21 +1,22 @@
 <div class="pl-6 relative pb-2">
-  <div class="text-m f-f-r py-2 pl-4">
-    <div class="flex items-center">
-      <label class="inline-flex items-center checkbox {{ sensorType }}">
-        <input
-          [checked]="(shown$ | async) && !fetchFailed"
-          [disabled]="fetchFailed"
-          (click)="toggleShown()"
-          type="checkbox"
-          class="h-5 w-5 text-blue-600"
-        />
-      </label>
-      <div class="ml-3">
-        <div [class.line-through]="fetchFailed" class="text-gray-400">
-          {{ sensorName }}
-        </div>
-      </div>
+  <div class="py-2 pl-4 flex items-center" (click)="toggleShown()">
+    <div class="inline-flex items-center checkbox {{ sensorType }}">
+      <input
+        [checked]="(shown$ | async) && !fetchFailed"
+        [disabled]="fetchFailed"
+        type="checkbox"
+        class="h-5 w-5 text-blue-600"
+        name="input-{{ sensorType }}"
+      />
     </div>
+    <label
+      [class.line-through]="fetchFailed"
+      [class.text-gray-400]="fetchFailed"
+      class="ml-3"
+      for="input-{{ sensorType }}"
+    >
+      {{ sensorName }}
+    </label>
   </div>
 
   <div

--- a/src/app/features/noah-playground/components/sensor-solo/sensor-solo.component.html
+++ b/src/app/features/noah-playground/components/sensor-solo/sensor-solo.component.html
@@ -8,8 +8,8 @@
         class="h-5 w-5 text-blue-600"
       />
     </label>
-    <div class="flex flex-col ml-3">
-      <div class="text-lg f-f-r">{{ sensorName }}</div>
+    <div class="ml-3">
+      <div class="">{{ sensorName }}</div>
     </div>
   </div>
 </div>

--- a/src/app/features/noah-playground/components/sensor-solo/sensor-solo.component.scss
+++ b/src/app/features/noah-playground/components/sensor-solo/sensor-solo.component.scss
@@ -4,6 +4,7 @@
   &,
   input {
     border-radius: 100% !important;
+    --border-color: #9ca3af;
   }
 }
 
@@ -13,6 +14,7 @@
   &,
   input {
     border-radius: 100% !important;
+    --border-color: #9ca3af;
   }
 }
 
@@ -22,6 +24,7 @@
   &,
   input {
     border-radius: 100% !important;
+    --border-color: #9ca3af;
   }
 }
 
@@ -31,5 +34,6 @@
   &,
   input {
     border-radius: 100% !important;
+    --border-color: #9ca3af;
   }
 }

--- a/src/app/features/noah-playground/components/sensor-solo/sensor-solo.component.ts
+++ b/src/app/features/noah-playground/components/sensor-solo/sensor-solo.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnInit } from '@angular/core';
+import { Component, Input, OnDestroy, OnInit } from '@angular/core';
 import { NoahPlaygroundService } from '@features/noah-playground/services/noah-playground.service';
 import { SensorType } from '@features/noah-playground/services/sensor.service';
 import { Observable, Subject } from 'rxjs';
@@ -15,7 +15,7 @@ export const SENSOR_NAMES: Record<SensorType, string> = {
   templateUrl: './sensor-solo.component.html',
   styleUrls: ['./sensor-solo.component.scss'],
 })
-export class SensorSoloComponent implements OnInit {
+export class SensorSoloComponent implements OnInit, OnDestroy {
   @Input() sensorType: SensorType;
 
   shown$: Observable<boolean>;
@@ -38,6 +38,11 @@ export class SensorSoloComponent implements OnInit {
         this.fetchFailed = !fetched;
         console.log(fetched);
       });
+  }
+
+  ngOnDestroy(): void {
+    this._unsub.next();
+    this._unsub.complete();
   }
 
   toggleShown() {

--- a/src/app/features/noah-playground/components/sensor-solo/sensor-solo.component.ts
+++ b/src/app/features/noah-playground/components/sensor-solo/sensor-solo.component.ts
@@ -1,7 +1,8 @@
 import { Component, Input, OnInit } from '@angular/core';
 import { NoahPlaygroundService } from '@features/noah-playground/services/noah-playground.service';
 import { SensorType } from '@features/noah-playground/services/sensor.service';
-import { Observable } from 'rxjs';
+import { Observable, Subject } from 'rxjs';
+import { takeUntil } from 'rxjs/operators';
 
 export const SENSOR_NAMES: Record<SensorType, string> = {
   arg: 'Automated Rain Gauge',
@@ -20,6 +21,8 @@ export class SensorSoloComponent implements OnInit {
   shown$: Observable<boolean>;
   fetchFailed: boolean;
 
+  private _unsub = new Subject();
+
   get sensorName(): string {
     return SENSOR_NAMES[this.sensorType];
   }
@@ -28,7 +31,13 @@ export class SensorSoloComponent implements OnInit {
 
   ngOnInit(): void {
     this.shown$ = this.pgService.getSensorTypeShown$(this.sensorType);
-    this.fetchFailed = true;
+    this.pgService
+      .getSensorTypeFetched$(this.sensorType)
+      .pipe(takeUntil(this._unsub))
+      .subscribe((fetched) => {
+        this.fetchFailed = !fetched;
+        console.log(fetched);
+      });
   }
 
   toggleShown() {

--- a/src/app/features/noah-playground/components/sensor-solo/sensor-solo.component.ts
+++ b/src/app/features/noah-playground/components/sensor-solo/sensor-solo.component.ts
@@ -18,6 +18,7 @@ export class SensorSoloComponent implements OnInit {
   @Input() sensorType: SensorType;
 
   shown$: Observable<boolean>;
+  fetchFailed: boolean;
 
   get sensorName(): string {
     return SENSOR_NAMES[this.sensorType];
@@ -27,6 +28,7 @@ export class SensorSoloComponent implements OnInit {
 
   ngOnInit(): void {
     this.shown$ = this.pgService.getSensorTypeShown$(this.sensorType);
+    this.fetchFailed = true;
   }
 
   toggleShown() {

--- a/src/app/features/noah-playground/components/sensor-solo/sensor-solo.component.ts
+++ b/src/app/features/noah-playground/components/sensor-solo/sensor-solo.component.ts
@@ -32,6 +32,7 @@ export class SensorSoloComponent implements OnInit {
   }
 
   toggleShown() {
+    if (this.fetchFailed) return;
     this.pgService.setSensorTypeShown(this.sensorType);
   }
 }

--- a/src/app/features/noah-playground/components/sensors-group/sensors-group.component.html
+++ b/src/app/features/noah-playground/components/sensors-group/sensors-group.component.html
@@ -70,8 +70,11 @@
   <div [ngClass]="(expanded$ | async) ? ' pt-5 ' : ' hidden '">
     <hr class="pb-2" />
 
-    <div class="pl-6" *ngFor="let sensorType of sensorTypes">
+    <div class="pl-6 relative pb-2" *ngFor="let sensorType of sensorTypes">
       <noah-sensor-solo [sensorType]="sensorType"></noah-sensor-solo>
+      <div class="absolute left-0 bottom-0 text-xs italic pl-16">
+        Unable to fetch data
+      </div>
     </div>
     <div>
       <p class="text-xs italic mt-2">

--- a/src/app/features/noah-playground/components/sensors-group/sensors-group.component.html
+++ b/src/app/features/noah-playground/components/sensors-group/sensors-group.component.html
@@ -70,13 +70,12 @@
   <div [ngClass]="(expanded$ | async) ? ' pt-5 ' : ' hidden '">
     <hr class="pb-2" />
 
-    <div class="pl-6 relative pb-2" *ngFor="let sensorType of sensorTypes">
-      <noah-sensor-solo [sensorType]="sensorType"></noah-sensor-solo>
-      <div class="absolute left-0 bottom-0 text-xs italic pl-16 ml-2">
-        Unable to fetch data
-      </div>
-    </div>
-    <div>
+    <noah-sensor-solo
+      *ngFor="let sensorType of sensorTypes"
+      [sensorType]="sensorType"
+    ></noah-sensor-solo>
+
+    <div class="pl-9">
       <p class="text-xs italic mt-2">
         Sensors data are from the stations deployed by DOST-ASTI, together with
         the help of DOST and PAGASA

--- a/src/app/features/noah-playground/components/sensors-group/sensors-group.component.html
+++ b/src/app/features/noah-playground/components/sensors-group/sensors-group.component.html
@@ -72,7 +72,7 @@
 
     <div class="pl-6 relative pb-2" *ngFor="let sensorType of sensorTypes">
       <noah-sensor-solo [sensorType]="sensorType"></noah-sensor-solo>
-      <div class="absolute left-0 bottom-0 text-xs italic pl-16">
+      <div class="absolute left-0 bottom-0 text-xs italic pl-16 ml-2">
         Unable to fetch data
       </div>
     </div>

--- a/src/app/features/noah-playground/services/noah-playground.service.ts
+++ b/src/app/features/noah-playground/services/noah-playground.service.ts
@@ -169,6 +169,12 @@ export class NoahPlaygroundService {
     );
   }
 
+  getSensorTypeFetched$(sensorType: SensorType): Observable<boolean> {
+    return this.store.state$.pipe(
+      map((state) => state.sensors.types[sensorType].fetched)
+    );
+  }
+
   setHazardTypeColor(
     color: NoahColor,
     hazardType: HazardType,
@@ -312,6 +318,18 @@ export class NoahPlaygroundService {
     this.store.patch(
       { sensors },
       `change sensor ${sensorType}'visibility to ${!shown}`
+    );
+  }
+
+  setSensorTypeFetched(sensorType: SensorType, fetched = true): void {
+    const sensors = {
+      ...this.store.state.sensors,
+    };
+
+    sensors.types[sensorType].fetched = fetched;
+    this.store.patch(
+      { sensors },
+      `change sensor's fetched status ${sensorType}' to ${!fetched}`
     );
   }
 

--- a/src/app/features/noah-playground/store/noah-playground.store.ts
+++ b/src/app/features/noah-playground/store/noah-playground.store.ts
@@ -224,8 +224,8 @@ const createInitialValue = (): NoahPlaygroundState => ({
   center: null,
   currentLocation: '-----',
   sensors: {
-    shown: false,
-    expanded: false,
+    shown: true,
+    expanded: true,
     types: {
       arg: {
         shown: true,

--- a/src/app/features/noah-playground/store/noah-playground.store.ts
+++ b/src/app/features/noah-playground/store/noah-playground.store.ts
@@ -229,8 +229,8 @@ const createInitialValue = (): NoahPlaygroundState => ({
   center: null,
   currentLocation: '-----',
   sensors: {
-    shown: true,
-    expanded: true,
+    shown: false,
+    expanded: false,
     types: {
       arg: {
         shown: true,

--- a/src/app/features/noah-playground/store/noah-playground.store.ts
+++ b/src/app/features/noah-playground/store/noah-playground.store.ts
@@ -92,10 +92,15 @@ export type CriticalFacilitiesState = {
   types: CriticalFacilityTypesState;
 };
 
+export type SensorTypeState = {
+  fetched: boolean;
+  shown: boolean;
+};
+
 export type SensorsState = {
   shown: boolean;
   expanded: boolean;
-  types: Record<SensorType, { shown: boolean }>;
+  types: Record<SensorType, SensorTypeState>;
 };
 
 type NoahPlaygroundState = {
@@ -229,15 +234,19 @@ const createInitialValue = (): NoahPlaygroundState => ({
     types: {
       arg: {
         shown: true,
+        fetched: false,
       },
       wlms: {
         shown: true,
+        fetched: false,
       },
       aws: {
         shown: true,
+        fetched: false,
       },
       wlmsarg: {
         shown: true,
+        fetched: false,
       },
     },
   },


### PR DESCRIPTION
# Summary

We need a way to visually handle the case where the sensors API do not return values. 

We'll show the following screen when the API throws an error

![image](https://user-images.githubusercontent.com/11599005/142246977-0fab5d50-0e0e-4760-bdb8-ce7d7fa3acf7.png)

The checkboxes will also be disabled when the data haven't been fetched yet

![Kapture 2021-11-18 at 01 01 09](https://user-images.githubusercontent.com/11599005/142247297-7b02060d-ac9c-4416-a2de-95a8148d3773.gif)


