### PR TITLE
fix(kyh): set default value of hazards assessment into Little to None

### DIFF
--- a/src/app/features/know-your-hazards/services/hazards.service.ts
+++ b/src/app/features/know-your-hazards/services/hazards.service.ts
@@ -191,7 +191,7 @@ export class HazardsService {
         return 'high';
 
       default:
-        return 'low';
+        return 'little to none';
     }
   }
 }


### PR DESCRIPTION
### screenshot sample
----

![image](https://user-images.githubusercontent.com/76890692/181207840-0537bd9b-593a-496b-a489-ae9bb0658f7c.png)

