### PR TITLE
feat(qc-iot): add tab navigation for different type in summary dashboard

### DIFF
--- a/src/app/features/noah-playground/components/map-playground/map-playground.component.ts
+++ b/src/app/features/noah-playground/components/map-playground/map-playground.component.ts
@@ -380,8 +380,6 @@ export class MapPlaygroundComponent implements OnInit, OnDestroy {
             popUp.setDOMContent(graphDiv).setMaxWidth('900px');
             _this.showQcChart(+pk, name, qcSensorType);
             _this._graphShown = true;
-            localStorage.setItem('pk', JSON.stringify(pk)); //getting PK everytime click the dots
-            _this.showUpdatePk();
           });
         } else {
           popUp.remove();
@@ -405,19 +403,7 @@ export class MapPlaygroundComponent implements OnInit, OnDestroy {
       popUp.remove();
     });
   }
-  //update pk and chart
-  async showUpdatePk() {
-    try {
-      const response: any = await this.qcSensorService
-        .getQcIotSensorData()
-        .pipe(first())
-        .toPromise();
-      localStorage.setItem(
-        'calendarDateTime',
-        JSON.stringify(response.results)
-      );
-    } catch (error) {}
-  }
+
   async showQcChart(
     pk: number,
     appID: string,
@@ -436,7 +422,6 @@ export class MapPlaygroundComponent implements OnInit, OnDestroy {
       rangeSelector: {
         enabled: true,
         allButtonsEnabled: true,
-        selected: 0,
         inputDateFormat: '%b %e, %Y %H:%M',
         buttons: [
           {
@@ -454,6 +439,7 @@ export class MapPlaygroundComponent implements OnInit, OnDestroy {
             text: 'All',
           },
         ],
+        selected: 0,
         buttonTheme: {
           width: 60,
         },
@@ -527,7 +513,7 @@ export class MapPlaygroundComponent implements OnInit, OnDestroy {
 
     chart.showLoading();
     const response: any = await this.qcSensorService
-      .getQcIotSensorData()
+      .getQcSensorData(pk)
       .pipe(first())
       .toPromise();
 

--- a/src/app/features/noah-playground/components/qc-sensor-solo/qc-sensor-solo.component.ts
+++ b/src/app/features/noah-playground/components/qc-sensor-solo/qc-sensor-solo.component.ts
@@ -5,8 +5,8 @@ import { Observable, Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 
 export const QC_SENSOR_NAMES: Record<QuezonCitySensorType, string> = {
-  rain: 'Rainfall',
   flood: 'Flood Height',
+  rain: 'Rainfall',
 };
 
 @Component({

--- a/src/app/features/noah-playground/components/qc-sensors-group/qc-sensors-group.component.ts
+++ b/src/app/features/noah-playground/components/qc-sensors-group/qc-sensors-group.component.ts
@@ -1,17 +1,12 @@
 import { Component, OnInit } from '@angular/core';
 import { NoahPlaygroundService } from '@features/noah-playground/services/noah-playground.service';
-import {
-  QCSENSORS,
-  QcSensorService,
-} from '@features/noah-playground/services/qc-sensor.service';
+import { QCSENSORS } from '@features/noah-playground/services/qc-sensor.service';
 import {
   QuezonCityCriticalFacilities,
   QuezonCityCriticalFacilitiesState,
   QuezonCitySensorType,
 } from '@features/noah-playground/store/noah-playground.store';
 import { Observable } from 'rxjs';
-import { first } from 'rxjs/operators';
-import { shareReplay } from 'rxjs/operators';
 @Component({
   selector: 'noah-qc-sensors-group',
   templateUrl: './qc-sensors-group.component.html',
@@ -28,30 +23,13 @@ export class QcSensorsGroupComponent implements OnInit {
   qcShown: QuezonCityCriticalFacilitiesState;
   disclaimerModal = false;
 
-  // get qcshown(): boolean {
-  //   return this.qcShown.qcshown;
-  // }
-
-  constructor(
-    private pgService: NoahPlaygroundService,
-    private qcSensorService: QcSensorService
-  ) {}
+  constructor(private pgService: NoahPlaygroundService) {}
 
   ngOnInit(): void {
     this.expanded$ = this.pgService.qcSensorsGroupExpanded$;
     this.shown$ = this.pgService.qcSensorsGroupShown$;
     this.qcshown$ = this.pgService.qcCriticalFacilitiesShown$;
     this.qcexpanded$ = this.pgService.qcCriticalFacilitiesExpanded$;
-    this.showdata();
-  }
-
-  //storing data to localstorage
-  async showdata() {
-    const response: any = await this.qcSensorService
-      .getQcIotSensorData()
-      .pipe(first())
-      .toPromise();
-    localStorage.setItem('calendarDateTime', JSON.stringify(response.results));
   }
 
   toggleExpansion() {
@@ -59,7 +37,6 @@ export class QcSensorsGroupComponent implements OnInit {
   }
 
   toggleShown(event: Event) {
-    this.showdata();
     event.stopPropagation();
     event.stopImmediatePropagation();
     this.pgService.toggleQuezonCityIOTGroupShown();

--- a/src/app/features/noah-playground/services/qc-sensor-chart.service.ts
+++ b/src/app/features/noah-playground/services/qc-sensor-chart.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Input } from '@angular/core';
+import { Injectable } from '@angular/core';
 import { QuezonCitySensorType } from '../store/noah-playground.store';
 import { QcSensorService } from '@features/noah-playground/services/qc-sensor.service';
 export type QCSensorChartOpts = {
@@ -11,7 +11,7 @@ export type QCSensorChartOpts = {
 })
 export class QcSensorChartService {
   pk: number;
-  constructor(private qcSensorService: QcSensorService) {}
+  constructor() {}
   getQcChartOpts(qcSensorType: QuezonCitySensorType) {
     switch (qcSensorType) {
       case 'flood':
@@ -28,63 +28,36 @@ export class QcSensorChartService {
       chart.showLoading('No Data Available');
     }
 
-    const calendarDate = JSON.parse(localStorage.getItem('calendarDateTime'));
-    const sortedCalendar = calendarDate.sort((a: any, b: any) => {
-      return (
-        new Date(a.received_at).getTime() - new Date(b.received_at).getTime()
-      );
-    });
-
-    // Y axis data for flood height
-    const processedData = calendarDate.map((el) => {
-      return [new Date(el.received_at).getTime(), el.distance_m];
-    });
-
-    // Y axis data for rainfall
-    const RainProcessedData = calendarDate.map((el) => {
-      return [new Date(el.received_at).getTime(), el.rain_accu];
-    });
-
     const sortedData = data.sort((a: any, b: any) => {
       return (
         new Date(a.received_at).getTime() - new Date(b.received_at).getTime()
       );
     });
 
+    const valueFloodaxis = data.map((el) => {
+      return [new Date(el.received_at).getTime(), el.distance_m];
+    });
+
+    const valueRainAxis = data.map((el) => {
+      return [new Date(el.received_at).getTime(), el.rain_accu];
+    });
+
     // set X axis
-    switch (qcSensorType) {
-      case 'flood':
-        chart.xAxis[0].update({
-          categories: processedData,
-          type: 'datetime',
-          labels: {
-            format: '{value:%b:%e:%H:%M}',
-          },
-        });
-        break;
-      default:
-        chart.xAxis[0].update({
-          categories: calendarDate.map((d) => d.dateTimeRead),
-          type: 'datetime',
-          labels: {
-            format: '{value:%b:%e:%H:%M}',
-          },
-        });
-        break;
-    }
+    chart.xAxis[0].update({
+      categories: sortedData,
+      type: 'datetime',
+      labels: {
+        format: '{value:%b:%e:%H:%M}',
+      },
+    });
+
     // set Y axis
     switch (qcSensorType) {
       case 'flood':
-        chart.series[0].setData(processedData), true;
+        chart.series[0].setData(valueFloodaxis), true;
         break;
       case 'rain':
-        chart.series[0].setData(RainProcessedData), true;
-        break;
-      default:
-        chart.series[0].setData(
-          sortedData.map((d) => Number(d.rain_accu)),
-          true
-        );
+        chart.series[0].setData(valueRainAxis), true;
         break;
     }
   }
@@ -96,6 +69,9 @@ export class QcSensorChartService {
         text: 'Rainfall',
       },
       yAxis: {
+        title: {
+          text: 'Millimeters (mm)',
+        },
         alignTicks: false,
         tickInterval: 0.5,
         color: '#0C2D48',
@@ -108,43 +84,40 @@ export class QcSensorChartService {
             label: {
               text: 'Light',
               style: {
-                color: 'black',
+                color: '#0C2D48',
               },
             },
           },
           {
             from: 2.5,
             to: 7.5,
-            // color: 'blue',
             color: '#0073ff',
             label: {
               text: 'Moderate',
               style: {
-                color: 'white',
+                color: '#0C2D48',
               },
             },
           },
           {
             from: 7.5,
             to: 15,
-            // color: 'dark blue',
             color: '#0011ad',
             label: {
               text: 'Heavy',
               style: {
-                color: 'white',
+                color: '#0C2D48',
               },
             },
           },
           {
             from: 15,
             to: 30,
-            // color: 'orange',
             color: '#fcba03',
             label: {
               text: 'Intense',
               style: {
-                color: 'black',
+                color: '#0C2D48',
               },
             },
           },
@@ -152,12 +125,11 @@ export class QcSensorChartService {
           {
             from: 30,
             to: 500,
-            // color: 'red',
             color: '#fc3d03',
             label: {
               text: 'Torrential',
               style: {
-                color: 'black',
+                color: '#0C2D48',
               },
             },
           },
@@ -166,7 +138,7 @@ export class QcSensorChartService {
       series: [
         {
           name: 'Rainfall',
-          // type: "xrange",
+          color: '#0C2D48',
           data: [],
           lineWidth: 1.5,
           marker: {
@@ -175,22 +147,15 @@ export class QcSensorChartService {
           hover: {
             lineWidth: 5,
           },
+          tooltip: {
+            valueSuffix: 'mm',
+          },
         },
       ],
     };
   }
   //FLOOD SENSORS
   private _getFloodHeightOtps(): any {
-    const calendarDate = JSON.parse(localStorage.getItem('calendarDateTime'));
-    const sortedCalendar = calendarDate.sort((a: any, b: any) => {
-      return (
-        new Date(a.received_at).getTime() - new Date(b.received_at).getTime()
-      );
-    });
-    const processedData = calendarDate.map((el) => {
-      return [new Date(el.received_at).getTime(), el.distance_m];
-    });
-
     return {
       chart: {
         type: 'spline',
@@ -203,6 +168,31 @@ export class QcSensorChartService {
         labels: {
           format: '{value:%b:%e:%H:%M}',
           align: 'left',
+        },
+      },
+      rangeSelector: {
+        enabled: true,
+        allButtonsEnabled: true,
+        selected: 0,
+        inputDateFormat: '%b %e, %Y %H:%M',
+        buttons: [
+          {
+            type: 'day',
+            count: 1,
+            text: '1 Day',
+          },
+          {
+            type: 'month',
+            count: 1,
+            text: '1 Month',
+          },
+          {
+            type: 'all',
+            text: 'All',
+          },
+        ],
+        buttonTheme: {
+          width: 60,
         },
       },
       yAxis: {
@@ -263,7 +253,7 @@ export class QcSensorChartService {
             lineWidth: 5,
           },
           tooltip: {
-            valueSuffix: '/m',
+            valueSuffix: 'm',
           },
         },
       ],

--- a/src/app/features/noah-playground/services/qc-sensor-chart.service.ts
+++ b/src/app/features/noah-playground/services/qc-sensor-chart.service.ts
@@ -262,6 +262,9 @@ export class QcSensorChartService {
           hover: {
             lineWidth: 5,
           },
+          tooltip: {
+            valueSuffix: '/m',
+          },
         },
       ],
     };

--- a/src/app/features/noah-playground/services/qc-sensor.service.ts
+++ b/src/app/features/noah-playground/services/qc-sensor.service.ts
@@ -24,7 +24,7 @@ export const QCCRITFAC: QuezonCityCriticalFacilities[] = [
   providedIn: 'root',
 })
 export class QcSensorService {
-  private QCBASE_URL = 'https://4137-136-158-11-6.ngrok.io';
+  private QCBASE_URL = 'https://iot-noah.up.edu.ph';
   loadOnceDisclaimer$ = forkJoin(this.getLoadOnceDisclaimer()).pipe(
     shareReplay(1)
   );

--- a/src/app/features/noah-playground/services/qc-sensor.service.ts
+++ b/src/app/features/noah-playground/services/qc-sensor.service.ts
@@ -25,6 +25,7 @@ export const QCCRITFAC: QuezonCityCriticalFacilities[] = [
 })
 export class QcSensorService {
   private QCBASE_URL = 'https://iot-noah.up.edu.ph';
+  //private QCBASE_URL = 'https://dcaf-136-158-11-127.ngrok.io';
   loadOnceDisclaimer$ = forkJoin(this.getLoadOnceDisclaimer()).pipe(
     shareReplay(1)
   );

--- a/src/app/features/noah-playground/services/qc-sensor.service.ts
+++ b/src/app/features/noah-playground/services/qc-sensor.service.ts
@@ -7,7 +7,7 @@ import {
 import { forkJoin, Observable, Subject } from 'rxjs';
 import { shareReplay, tap } from 'rxjs/operators';
 
-export const QCSENSORS: QuezonCitySensorType[] = ['rain', 'flood'];
+export const QCSENSORS: QuezonCitySensorType[] = ['flood', 'rain'];
 
 export type SummaryItem = {
   name: string;
@@ -24,8 +24,7 @@ export const QCCRITFAC: QuezonCityCriticalFacilities[] = [
   providedIn: 'root',
 })
 export class QcSensorService {
-  private QCBASE_URL = 'https://iot-noah.up.edu.ph';
-  //private QCBASE_URL = 'https://dcaf-136-158-11-127.ngrok.io';
+  private QCBASE_URL = 'https://4137-136-158-11-6.ngrok.io';
   loadOnceDisclaimer$ = forkJoin(this.getLoadOnceDisclaimer()).pipe(
     shareReplay(1)
   );
@@ -49,14 +48,11 @@ export class QcSensorService {
   }
 
   getQcSensorData(pk: number): Observable<any> {
-    return this.http.get(`${this.QCBASE_URL}/api/iot-data/?id=${pk}`);
+    return this.http.get(`${this.QCBASE_URL}/api/iot-data/?iot_sensor=${pk}`);
   }
 
-  getQcIotSensorData() {
-    const sensor_id = JSON.parse(localStorage.getItem('pk'));
-    return this.http.get(
-      `${this.QCBASE_URL}/api/iot-data/?iot_sensor=${sensor_id}`
-    );
+  getIotSummarySensorData(pk: number): Observable<any> {
+    return this.http.get(`${this.QCBASE_URL}/api/iot-data/?id=${pk}`);
   }
 
   getLoadOnceDisclaimer() {

--- a/src/app/shared/components/summary/summary.component.html
+++ b/src/app/shared/components/summary/summary.component.html
@@ -55,134 +55,6 @@
     (click)="closeModal()"
   ></div>
   <!--content-->
-
-  <div class="max-w-3xl mx-auto px-8 sm:px-0">
-    <div class="sm:w-7/12 sm:mx-auto">
-      <div
-        role="tablist"
-        aria-label="tabs"
-        class="
-          relative
-          w-max
-          mx-auto
-          h-12
-          grid grid-cols-3
-          items-center
-          px-[3px]
-          rounded-full
-          bg-gray-900/20
-          overflow-hidden
-          shadow-2xl shadow-900/20
-          transition
-        "
-      >
-        <div
-          class="
-            absolute
-            indicator
-            h-11
-            my-auto
-            top-0
-            bottom-0
-            left-0
-            rounded-full
-            bg-white
-            shadow-md
-          "
-        ></div>
-        <button
-          role="tab"
-          aria-selected="true"
-          aria-controls="panel-1"
-          id="tab-1"
-          tabindex="0"
-          class="relative block h-10 px-6 tab rounded-full"
-        >
-          <span class="text-gray-800">First Tab</span>
-        </button>
-        <button
-          role="tab"
-          aria-selected="false"
-          aria-controls="panel-2"
-          id="tab-2"
-          tabindex="-1"
-          class="relative block h-10 px-6 tab rounded-full"
-        >
-          <span class="text-gray-800">Second Tab</span>
-        </button>
-        <button
-          role="tab"
-          aria-selected="false"
-          aria-controls="panel-3"
-          id="tab-3"
-          tabindex="-1"
-          class="relative block h-10 px-6 tab rounded-full"
-        >
-          <span class="text-gray-800">Third Tab</span>
-        </button>
-      </div>
-      <div class="mt-6 relative rounded-3xl bg-purple-50">
-        <div
-          role="tabpanel"
-          id="panel-1"
-          class="tab-panel p-6 transition duration-300"
-        >
-          <h2 class="text-xl font-semibold text-gray-800">First tab panel</h2>
-          <p class="mt-4 text-gray-600">
-            Lorem, ipsum dolor sit amet consectetur adipisicing elit. Quas
-            dolores voluptate temporibus, atque ab eos, delectus at ad hic
-            voluptatem veritatis iure, nulla voluptates quod nobis doloremque
-            eaque! Perferendis, soluta.
-          </p>
-        </div>
-        <div
-          role="tabpanel"
-          id="panel-2"
-          class="
-            absolute
-            top-0
-            invisible
-            opacity-0
-            tab-panel
-            p-6
-            transition
-            duration-300
-          "
-        >
-          <h2 class="text-xl font-semibold text-gray-800">Second tab panel</h2>
-          <p class="mt-4 text-gray-600">
-            Lorem, ipsum dolor sit amet consectetur adipisicing elit. Quas
-            dolores voluptate temporibus, atque ab eos, delectus at ad hic
-            voluptatem veritatis iure, nulla voluptates quod nobis doloremque
-            eaque! Perferendis, soluta.
-          </p>
-        </div>
-        <div
-          role="tabpanel"
-          id="panel-3"
-          class="
-            absolute
-            top-0
-            invisible
-            opacity-0
-            tab-panel
-            p-6
-            transition
-            duration-300
-          "
-        >
-          <h2 class="text-xl font-semibold text-gray-800">Third tab panel</h2>
-          <p class="mt-4 text-gray-600">
-            Lorem, ipsum dolor sit amet consectetur adipisicing elit. Quas
-            dolores voluptate temporibus, atque ab eos, delectus at ad hic
-            voluptatem veritatis iure, nulla voluptates quod nobis doloremque
-            eaque! Perferendis, soluta.
-          </p>
-        </div>
-      </div>
-    </div>
-  </div>
-
   <div class="min-w-screen min-h-screen flex items-center z-40 justify-center">
     <div
       class="
@@ -243,6 +115,12 @@
                   <p class="italic lg:text-lg text-sm">
                     As of {{ todayString | date: 'fullDate' }}
                   </p>
+                  <p class="lg:text-sm text-sm">
+                    <b class="text-primary">{{ activeFloodSensor }}</b>
+                    Active Flood Sensors |
+                    <b class="text-primary">{{ rainActiveSensor }}</b> Active
+                    Rainfall Sensors
+                  </p>
                 </div>
 
                 <input
@@ -262,421 +140,1422 @@
                   "
                 />
 
-                <ng-container *ngIf="loading; else dataSummary">
-                  <div tabindex="0" class="justify-center">
-                    <div
-                      class="shadow-xl w-full z-10 overflow-hidden"
-                      style="max-width: 1000px"
-                    >
-                      <div class="md:flex w-full">
-                        <div class="w-full py-10 px-5 md:px-10">
-                          <div class="flex justify-center gap-x-4 mb-4">
-                            <div
-                              class="flex items-center justify-center bottom-0"
-                            >
-                              <div
-                                class="
-                                  w-14
-                                  h-14
-                                  border-t-4 border-b-4 border-black
-                                  rounded-full
-                                  animate-spin
-                                  absolute
-                                "
-                              ></div>
-                              <img
-                                src="assets/icons/logo-noah.svg"
-                                class="w-10 h-10 animate-none"
-                                fill="none"
-                              />
-                            </div>
-                          </div>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                </ng-container>
-                <ng-template #dataSummary>
-                  <div class="mt-2">
-                    <div
-                      class="overflow-auto rounded-lg shadow hidden md:block"
-                    >
-                      <table class="w-full b-4">
-                        <thead class="bg-gray-50 border-b-2 border-gray-200">
-                          <tr>
-                            <th
-                              class="
-                                p-3
-                                text-sm
-                                font-semibold
-                                tracking-wide
-                                text-left
-                              "
-                              *ngFor="let col of columns"
-                            >
-                              <div
-                                (click)="sortedColumn = col.key"
-                                class="cursor-pointer inline-flex"
-                              >
-                                {{ col.header }}
-                                <svg
-                                  xmlns="http://www.w3.org/2000/svg"
-                                  class="mr-1 h-5 w-5 text-left"
-                                  viewBox="0 0 20 20"
-                                  fill="currentColor"
-                                >
-                                  <path
-                                    d="M3 3a1 1 0 000 2h11a1 1 0 100-2H3zM3 7a1 1 0 000 2h5a1 1 0 000-2H3zM3 11a1 1 0 100 2h4a1 1 0 100-2H3zM13 16a1 1 0 102 0v-5.586l1.293 1.293a1 1 0 001.414-1.414l-3-3a1 1 0 00-1.414 0l-3 3a1 1 0 101.414 1.414L13 10.414V16z"
-                                  />
-                                </svg>
-                              </div>
-                            </th>
-                          </tr>
-                        </thead>
-                        <tbody class="divide-y divide-gray-100">
-                          <tr
-                            class="hover:bg-gray-100 bg-white"
-                            *ngFor="
-                              let data of summaryData
-                                | sort: sortedColumn
-                                | searchfilter: searchValue
-                            "
-                          >
-                            <td
-                              class="
-                                p-3
-                                text-sm text-gray-700
-                                whitespace-nowrap
-                              "
-                            >
-                              {{ data.name }}
-                            </td>
-                            <td
-                              class="
-                                p-3
-                                text-sm text-gray-700
-                                whitespace-nowrap
-                                first-letter:capitalize
-                              "
-                            >
-                              {{ data.iot_type }}
-                            </td>
-
-                            <td
-                              class="
-                                p-3
-                                text-sm text-gray-700
-                                whitespace-nowrap
-                              "
-                            >
-                              {{ data.latest_date | date: 'medium':'+0000' }}
-                            </td>
-
-                            <td
-                              class="
-                                p-3
-                                text-sm text-gray-700
-                                whitespace-nowrap
-                                text-center
-                                justify-center
-                              "
-                            >
-                              {{ data.latest_data }}
-                            </td>
-
-                            <td
-                              class="
-                                p-3
-                                text-sm text-gray-700
-                                whitespace-nowrap
-                              "
-                            >
-                              <div
-                                *ngIf="
-                                  data.latest_data <= '0' &&
-                                  data.latest_data <= '0.5'
-                                "
-                              >
-                                <span
-                                  class="
-                                    p-1.5
-                                    text-xs
-                                    font-medium
-                                    uppercase
-                                    tracking-wider
-                                    text-black
-                                    bg-low
-                                    rounded-lg
-                                  "
-                                  >Low (0 - 0.5m)</span
-                                >
-                              </div>
-                              <div
-                                *ngIf="
-                                  data.latest_data >= '0.6' &&
-                                  data.latest_data >= '1.5'
-                                "
-                              >
-                                <span
-                                  class="
-                                    p-1.5
-                                    text-xs
-                                    font-medium
-                                    uppercase
-                                    tracking-wider
-                                    text-black
-                                    bg-medium
-                                    rounded-lg
-                                  "
-                                  >Medium (0.6 - 1.5m)</span
-                                >
-                              </div>
-                              <div
-                                *ngIf="
-                                  data.latest_data >= '1.6' &&
-                                  data.latest_data <= '2'
-                                "
-                              >
-                                <span
-                                  class="
-                                    p-1.5
-                                    text-xs
-                                    font-medium
-                                    uppercase
-                                    tracking-wider
-                                    text-black
-                                    bg-high
-                                    rounded-lg
-                                  "
-                                >
-                                  High (1.6m +)
-                                </span>
-                              </div>
-                            </td>
-                          </tr>
-                        </tbody>
-                      </table>
-                    </div>
-                    <noah-pagination
-                      class="hidden md:block"
-                      [allPagesNumber]="allPages"
-                      (changePage)="onPageChange($event)"
-                    ></noah-pagination>
-                    <!-- MOBILE VIEW -->
-                    <div
-                      class="z-10 pl-2 h-16 w-36 flex flex-row py-2 md:hidden"
-                    >
-                      <div class="p-2">
-                        <div class="dropdown inline-block relative">
-                          <button
-                            class="
-                              bg-gray-200
-                              text-gray-800
-                              font-semibold
-                              py-1
-                              px-1
-                              ml-2
-                              rounded
-                              inline-flex
-                              items-center
-                              hover:bg-gray-200
-                              focus:outline-none
-                              focus:ring-2
-                              focus:ring-gray-600
-                              focus:ring-opacity-50
-                            "
-                          >
-                            Sort By:
-                          </button>
-                          <ul
-                            class="
-                              dropdown-menu
-                              z-50
-                              rounded-lg
-                              drop-shadow-xl
-                              bg-white
-                              left-20
-                              top-0
-                              absolute
-                              hidden
-                              text-sm text-gray-700
-                              w-32
-                              h-48
-                              overflow-y-auto
-                            "
-                          >
-                            <li class="w-32" *ngFor="let col of columns">
-                              <a
-                                class="
-                                  rounded-lg
-                                  block
-                                  px-4
-                                  py-2
-                                  text-sm
-                                  leading-5
-                                  text-gray-700
-                                  transition
-                                  duration-150
-                                  ease-in-out
-                                  hover:bg-gray-100
-                                  focus:outline-none focus:bg-gray-100
-                                "
-                                (click)="sortedColumn = col.key"
-                                role="button"
-                                >{{ col.mobileHeader }}</a
-                              >
-                            </li>
-                          </ul>
-                        </div>
-                      </div>
-                    </div>
-
-                    <div
-                      class="
-                        items-center
-                        justify-center
-                        py-2
-                        px-3
-                        md:hidden
-                        grid grid-cols-1
-                        h-96
-                        overflow-y-auto
-                        sm:grid-cols-2
-                        gap-4
-                      "
-                    >
-                      <div
-                        class="
-                          md:w-96
-                          rounded-md
-                          drop-shadow-2xl
-                          py-4
-                          px-5
-                          w-full
-                          bg-white
-                        "
-                        *ngFor="
-                          let data of summaryData
-                            | sort: sortedColumn
-                            | searchfilter: searchValue
-                        "
+                <nav class="tab-navigation">
+                  <ul class="tab-navigation">
+                    <li class="nav-item">
+                      <label class="nav-link" tabindex="1" for="select-all"
+                        >All</label
                       >
-                        <h1
-                          class="text-lg font-bold text-gray-800 leading-5 pt-2"
-                        >
-                          {{ data.name }}
-                        </h1>
-                        <div class="pt-2 relative">
-                          <div class="flex items-center justify-between">
-                            <div class="flex items-center">
-                              <div
-                                class="w-2 h-2 rounded-full bg-blue-500"
-                              ></div>
-                              <span
-                                class="
-                                  text-blue-500 text-xs
-                                  italic
-                                  font-normal
-                                  pl-1
-                                "
-                              >
-                                {{ data.latest_date | date: 'medium':'+0000' }}
-                              </span>
-                            </div>
-                          </div>
-                          <p
-                            class="
-                              text-sm
-                              leading-none
-                              pt-2
-                              text-gray-600
-                              first
-                              capitalize
-                            "
-                          >
-                            Sensor Type: {{ data.iot_type }}
-                          </p>
-                          <p
-                            class="text-xs italic pt-1 leading-3 text-gray-400"
-                          >
-                            Latest Data: {{ data.latest_data }}
-                          </p>
+                    </li>
+                    <li class="nav-item">
+                      <label class="nav-link" tabindex="1" for="select-flood"
+                        >Flood Sensor</label
+                      >
+                    </li>
+                    <li class="nav-item">
+                      <label class="nav-link" tabindex="1" for="select-rain"
+                        >Rainfall Sensor</label
+                      >
+                    </li>
+                  </ul>
+                </nav>
+
+                <section>
+                  <!-- TAB SECTION FOR ALL -->
+                  <article class="tab-all">
+                    <input
+                      type="radio"
+                      name="tab-indicator"
+                      id="select-all"
+                      class="tab-indicator"
+                      checked="checked"
+                    />
+                    <div class="tab-content">
+                      <ng-container *ngIf="loading; else dataSummaryall">
+                        <div tabindex="0" class="justify-center">
                           <div
-                            class="flex items-center justify-left"
-                            *ngIf="
-                              data.latest_data <= '0' ||
-                              data.latest_data <= '0.5'
-                            "
+                            class="shadow-xl w-full z-10 overflow-hidden"
+                            style="max-width: 1000px"
                           >
-                            <div
-                              class="
-                                text-yellow-400
-                                bg-yellow-200
-                                py-1
-                                px-2
-                                rounded
-                                text-xs
-                                leading-3
-                                mt-2
-                                pl-2
-                              "
-                            >
-                              Low (0 - 0.5m)
-                            </div>
-                          </div>
-                          <div
-                            class="flex items-center justify-left"
-                            *ngIf="
-                              data.latest_data >= '0.6' ||
-                              data.latest_data >= '1.5'
-                            "
-                          >
-                            <div
-                              class="
-                                text-yellow-600
-                                bg-yellow-400
-                                py-1
-                                px-2
-                                rounded
-                                text-xs
-                                leading-3
-                                mt-2
-                                pl-2
-                              "
-                            >
-                              Medium (0.5 - 1.5m)
-                            </div>
-                          </div>
-                          <div
-                            class="flex items-center justify-left"
-                            *ngIf="
-                              data.latest_data >= '1.6' ||
-                              data.latest_data >= '2'
-                            "
-                          >
-                            <div
-                              class="
-                                text-red-600
-                                bg-red-400
-                                py-1
-                                px-2
-                                rounded
-                                text-xs
-                                leading-3
-                                mt-2
-                                pl-2
-                              "
-                            >
-                              High (1.5m +)
+                            <div class="md:flex w-full">
+                              <div class="w-full py-10 px-5 md:px-10">
+                                <div class="flex justify-center gap-x-4 mb-4">
+                                  <div
+                                    class="
+                                      flex
+                                      items-center
+                                      justify-center
+                                      bottom-0
+                                    "
+                                  >
+                                    <div
+                                      class="
+                                        w-14
+                                        h-14
+                                        border-t-4 border-b-4 border-black
+                                        rounded-full
+                                        animate-spin
+                                        absolute
+                                      "
+                                    ></div>
+                                    <img
+                                      src="assets/icons/logo-noah.svg"
+                                      class="w-10 h-10 animate-none"
+                                      fill="none"
+                                    />
+                                  </div>
+                                </div>
+                              </div>
                             </div>
                           </div>
                         </div>
-                      </div>
-                    </div>
+                      </ng-container>
+                      <ng-template #dataSummaryall>
+                        <div class="mt-2">
+                          <div
+                            class="
+                              overflow-auto
+                              rounded-lg
+                              shadow
+                              hidden
+                              md:block
+                            "
+                          >
+                            <table class="w-full b-4">
+                              <thead
+                                class="bg-gray-50 border-b-2 border-gray-200"
+                              >
+                                <tr>
+                                  <th
+                                    class="
+                                      p-3
+                                      text-sm
+                                      font-semibold
+                                      tracking-wide
+                                      text-left
+                                    "
+                                    *ngFor="let col of columns"
+                                  >
+                                    <div
+                                      (click)="sortedColumn = col.key"
+                                      class="cursor-pointer inline-flex"
+                                    >
+                                      {{ col.header }}
+                                      <svg
+                                        xmlns="http://www.w3.org/2000/svg"
+                                        class="mr-1 h-5 w-5 text-left"
+                                        viewBox="0 0 20 20"
+                                        fill="currentColor"
+                                      >
+                                        <path
+                                          d="M3 3a1 1 0 000 2h11a1 1 0 100-2H3zM3 7a1 1 0 000 2h5a1 1 0 000-2H3zM3 11a1 1 0 100 2h4a1 1 0 100-2H3zM13 16a1 1 0 102 0v-5.586l1.293 1.293a1 1 0 001.414-1.414l-3-3a1 1 0 00-1.414 0l-3 3a1 1 0 101.414 1.414L13 10.414V16z"
+                                        />
+                                      </svg>
+                                    </div>
+                                  </th>
+                                </tr>
+                              </thead>
+                              <tbody class="divide-y divide-gray-100">
+                                <tr
+                                  class="hover:bg-gray-100 bg-white"
+                                  *ngFor="
+                                    let data of summaryData
+                                      | sort: sortedColumn
+                                      | searchfilter: searchValue
+                                  "
+                                >
+                                  <td
+                                    class="
+                                      p-3
+                                      text-sm text-gray-700
+                                      whitespace-nowrap
+                                    "
+                                  >
+                                    {{ data.name }}
+                                  </td>
+                                  <td
+                                    class="
+                                      p-3
+                                      text-sm text-gray-700
+                                      whitespace-nowrap
+                                      first-letter:capitalize
+                                    "
+                                  >
+                                    {{ data.iot_type }}
+                                  </td>
 
-                    <!-- MOBILE VIEW -->
-                  </div>
-                </ng-template>
+                                  <td
+                                    class="
+                                      p-3
+                                      text-sm text-gray-700
+                                      whitespace-nowrap
+                                    "
+                                  >
+                                    {{
+                                      data.latest_date | date: 'medium':'+0000'
+                                    }}
+                                  </td>
+
+                                  <td
+                                    class="
+                                      p-3
+                                      text-sm text-gray-700
+                                      whitespace-nowrap
+                                      text-center
+                                      justify-center
+                                    "
+                                  >
+                                    {{ data.latest_data }}
+                                  </td>
+
+                                  <td
+                                    class="
+                                      p-3
+                                      text-sm text-gray-700
+                                      whitespace-nowrap
+                                    "
+                                  >
+                                    <div
+                                      *ngIf="
+                                        data.latest_data <= '0' &&
+                                        data.latest_data <= '0.5'
+                                      "
+                                    >
+                                      <span
+                                        class="
+                                          p-1.5
+                                          text-xs
+                                          font-medium
+                                          uppercase
+                                          tracking-wider
+                                          text-black
+                                          bg-low
+                                          rounded-lg
+                                        "
+                                        >Low (0 - 0.5m)</span
+                                      >
+                                    </div>
+                                    <div
+                                      *ngIf="
+                                        data.latest_data >= '0.6' &&
+                                        data.latest_data >= '1.5'
+                                      "
+                                    >
+                                      <span
+                                        class="
+                                          p-1.5
+                                          text-xs
+                                          font-medium
+                                          uppercase
+                                          tracking-wider
+                                          text-black
+                                          bg-medium
+                                          rounded-lg
+                                        "
+                                        >Medium (0.6 - 1.5m)</span
+                                      >
+                                    </div>
+                                    <div
+                                      *ngIf="
+                                        data.latest_data >= '1.6' &&
+                                        data.latest_data <= '2'
+                                      "
+                                    >
+                                      <span
+                                        class="
+                                          p-1.5
+                                          text-xs
+                                          font-medium
+                                          uppercase
+                                          tracking-wider
+                                          text-black
+                                          bg-high
+                                          rounded-lg
+                                        "
+                                      >
+                                        High (1.6m +)
+                                      </span>
+                                    </div>
+                                  </td>
+                                </tr>
+                              </tbody>
+                            </table>
+                          </div>
+                          <noah-pagination
+                            class="hidden md:block"
+                            [allPagesNumber]="allPages"
+                            (changePage)="onPageChange($event)"
+                          ></noah-pagination>
+                          <!-- MOBILE VIEW -->
+                          <div
+                            class="
+                              z-10
+                              pl-2
+                              h-16
+                              w-36
+                              flex flex-row
+                              py-2
+                              md:hidden
+                            "
+                          >
+                            <div class="p-2">
+                              <div class="dropdown inline-block relative">
+                                <button
+                                  class="
+                                    bg-gray-200
+                                    text-gray-800
+                                    font-semibold
+                                    py-1
+                                    px-1
+                                    ml-2
+                                    rounded
+                                    inline-flex
+                                    items-center
+                                    hover:bg-gray-200
+                                    focus:outline-none
+                                    focus:ring-2
+                                    focus:ring-gray-600
+                                    focus:ring-opacity-50
+                                  "
+                                >
+                                  Sort By:
+                                </button>
+                                <ul
+                                  class="
+                                    dropdown-menu
+                                    z-50
+                                    rounded-lg
+                                    drop-shadow-xl
+                                    bg-white
+                                    left-20
+                                    top-0
+                                    absolute
+                                    hidden
+                                    text-sm text-gray-700
+                                    w-32
+                                    h-48
+                                    overflow-y-auto
+                                  "
+                                >
+                                  <li class="w-32" *ngFor="let col of columns">
+                                    <a
+                                      class="
+                                        rounded-lg
+                                        block
+                                        px-4
+                                        py-2
+                                        text-sm
+                                        leading-5
+                                        text-gray-700
+                                        transition
+                                        duration-150
+                                        ease-in-out
+                                        hover:bg-gray-100
+                                        focus:outline-none focus:bg-gray-100
+                                      "
+                                      (click)="sortedColumn = col.key"
+                                      role="button"
+                                      >{{ col.mobileHeader }}</a
+                                    >
+                                  </li>
+                                </ul>
+                              </div>
+                            </div>
+                          </div>
+
+                          <div
+                            class="
+                              items-center
+                              justify-center
+                              py-2
+                              px-3
+                              md:hidden
+                              grid grid-cols-1
+                              h-96
+                              overflow-y-auto
+                              sm:grid-cols-2
+                              gap-4
+                            "
+                          >
+                            <div
+                              class="
+                                md:w-96
+                                rounded-md
+                                drop-shadow-2xl
+                                py-4
+                                px-5
+                                w-full
+                                bg-white
+                              "
+                              *ngFor="
+                                let data of summaryData
+                                  | sort: sortedColumn
+                                  | searchfilter: searchValue
+                              "
+                            >
+                              <h1
+                                class="
+                                  text-lg
+                                  font-bold
+                                  text-gray-800
+                                  leading-5
+                                  pt-2
+                                "
+                              >
+                                {{ data.name }}
+                              </h1>
+                              <div class="pt-2 relative">
+                                <div class="flex items-center justify-between">
+                                  <div class="flex items-center">
+                                    <div
+                                      class="w-2 h-2 rounded-full bg-blue-500"
+                                    ></div>
+                                    <span
+                                      class="
+                                        text-blue-500 text-xs
+                                        italic
+                                        font-normal
+                                        pl-1
+                                      "
+                                    >
+                                      {{
+                                        data.latest_date
+                                          | date: 'medium':'+0000'
+                                      }}
+                                    </span>
+                                  </div>
+                                </div>
+                                <p
+                                  class="
+                                    text-sm
+                                    leading-none
+                                    pt-2
+                                    text-gray-600
+                                    first
+                                    capitalize
+                                  "
+                                >
+                                  Sensor Type: {{ data.iot_type }}
+                                </p>
+                                <p
+                                  class="
+                                    text-xs
+                                    italic
+                                    pt-1
+                                    leading-3
+                                    text-gray-400
+                                  "
+                                >
+                                  Latest Data: {{ data.latest_data }}
+                                </p>
+                                <div
+                                  class="flex items-center justify-left"
+                                  *ngIf="
+                                    data.latest_data <= '0' ||
+                                    data.latest_data <= '0.5'
+                                  "
+                                >
+                                  <div
+                                    class="
+                                      text-yellow-400
+                                      bg-yellow-200
+                                      py-1
+                                      px-2
+                                      rounded
+                                      text-xs
+                                      leading-3
+                                      mt-2
+                                      pl-2
+                                    "
+                                  >
+                                    Low (0 - 0.5m)
+                                  </div>
+                                </div>
+                                <div
+                                  class="flex items-center justify-left"
+                                  *ngIf="
+                                    data.latest_data >= '0.6' ||
+                                    data.latest_data >= '1.5'
+                                  "
+                                >
+                                  <div
+                                    class="
+                                      text-yellow-600
+                                      bg-yellow-400
+                                      py-1
+                                      px-2
+                                      rounded
+                                      text-xs
+                                      leading-3
+                                      mt-2
+                                      pl-2
+                                    "
+                                  >
+                                    Medium (0.5 - 1.5m)
+                                  </div>
+                                </div>
+                                <div
+                                  class="flex items-center justify-left"
+                                  *ngIf="
+                                    data.latest_data >= '1.6' ||
+                                    data.latest_data >= '2'
+                                  "
+                                >
+                                  <div
+                                    class="
+                                      text-red-600
+                                      bg-red-400
+                                      py-1
+                                      px-2
+                                      rounded
+                                      text-xs
+                                      leading-3
+                                      mt-2
+                                      pl-2
+                                    "
+                                  >
+                                    High (1.5m +)
+                                  </div>
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+
+                          <!-- MOBILE VIEW -->
+                        </div>
+                      </ng-template>
+                    </div>
+                  </article>
+
+                  <!-- TAB SECTION FOR FLOOD -->
+                  <article class="tab-flood">
+                    <input
+                      type="radio"
+                      name="tab-indicator"
+                      id="select-flood"
+                      class="tab-indicator"
+                    />
+                    <div class="tab-content">
+                      <ng-container *ngIf="loading; else dataSummaryFlood">
+                        <div tabindex="0" class="justify-center">
+                          <div
+                            class="shadow-xl w-full z-10 overflow-hidden"
+                            style="max-width: 1000px"
+                          >
+                            <div class="md:flex w-full">
+                              <div class="w-full py-10 px-5 md:px-10">
+                                <div class="flex justify-center gap-x-4 mb-4">
+                                  <div
+                                    class="
+                                      flex
+                                      items-center
+                                      justify-center
+                                      bottom-0
+                                    "
+                                  >
+                                    <div
+                                      class="
+                                        w-14
+                                        h-14
+                                        border-t-4 border-b-4 border-black
+                                        rounded-full
+                                        animate-spin
+                                        absolute
+                                      "
+                                    ></div>
+                                    <img
+                                      src="assets/icons/logo-noah.svg"
+                                      class="w-10 h-10 animate-none"
+                                      fill="none"
+                                    />
+                                  </div>
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                      </ng-container>
+                      <ng-template #dataSummaryFlood>
+                        <div class="mt-2">
+                          <div
+                            class="
+                              overflow-auto
+                              rounded-lg
+                              shadow
+                              hidden
+                              md:block
+                            "
+                          >
+                            <table class="w-full b-4">
+                              <thead
+                                class="bg-gray-50 border-b-2 border-gray-200"
+                              >
+                                <tr>
+                                  <th
+                                    class="
+                                      p-3
+                                      text-sm
+                                      font-semibold
+                                      tracking-wide
+                                      text-left
+                                    "
+                                    *ngFor="let col of columns"
+                                  >
+                                    <div
+                                      (click)="sortedColumn = col.key"
+                                      class="cursor-pointer inline-flex"
+                                    >
+                                      {{ col.header }}
+                                      <svg
+                                        xmlns="http://www.w3.org/2000/svg"
+                                        class="mr-1 h-5 w-5 text-left"
+                                        viewBox="0 0 20 20"
+                                        fill="currentColor"
+                                      >
+                                        <path
+                                          d="M3 3a1 1 0 000 2h11a1 1 0 100-2H3zM3 7a1 1 0 000 2h5a1 1 0 000-2H3zM3 11a1 1 0 100 2h4a1 1 0 100-2H3zM13 16a1 1 0 102 0v-5.586l1.293 1.293a1 1 0 001.414-1.414l-3-3a1 1 0 00-1.414 0l-3 3a1 1 0 101.414 1.414L13 10.414V16z"
+                                        />
+                                      </svg>
+                                    </div>
+                                  </th>
+                                </tr>
+                              </thead>
+                              <tbody class="divide-y divide-gray-100">
+                                <tr
+                                  class="hover:bg-gray-100 bg-white"
+                                  *ngFor="
+                                    let data of floodSummaryData
+                                      | sort: sortedColumn
+                                      | searchfilter: searchValue
+                                  "
+                                >
+                                  <td
+                                    class="
+                                      p-3
+                                      text-sm text-gray-700
+                                      whitespace-nowrap
+                                    "
+                                  >
+                                    {{ data.name }}
+                                  </td>
+                                  <td
+                                    class="
+                                      p-3
+                                      text-sm text-gray-700
+                                      whitespace-nowrap
+                                      first-letter:capitalize
+                                    "
+                                  >
+                                    {{ data.iot_type }}
+                                  </td>
+
+                                  <td
+                                    class="
+                                      p-3
+                                      text-sm text-gray-700
+                                      whitespace-nowrap
+                                    "
+                                  >
+                                    {{
+                                      data.latest_date | date: 'medium':'+0000'
+                                    }}
+                                  </td>
+
+                                  <td
+                                    class="
+                                      p-3
+                                      text-sm text-gray-700
+                                      whitespace-nowrap
+                                      text-center
+                                      justify-center
+                                    "
+                                  >
+                                    {{ data.latest_data }}
+                                  </td>
+
+                                  <td
+                                    class="
+                                      p-3
+                                      text-sm text-gray-700
+                                      whitespace-nowrap
+                                    "
+                                  >
+                                    <div
+                                      *ngIf="
+                                        data.latest_data <= '0' &&
+                                        data.latest_data <= '0.5'
+                                      "
+                                    >
+                                      <span
+                                        class="
+                                          p-1.5
+                                          text-xs
+                                          font-medium
+                                          uppercase
+                                          tracking-wider
+                                          text-black
+                                          bg-low
+                                          rounded-lg
+                                        "
+                                        >Low (0 - 0.5m)</span
+                                      >
+                                    </div>
+                                    <div
+                                      *ngIf="
+                                        data.latest_data >= '0.6' &&
+                                        data.latest_data >= '1.5'
+                                      "
+                                    >
+                                      <span
+                                        class="
+                                          p-1.5
+                                          text-xs
+                                          font-medium
+                                          uppercase
+                                          tracking-wider
+                                          text-black
+                                          bg-medium
+                                          rounded-lg
+                                        "
+                                        >Medium (0.6 - 1.5m)</span
+                                      >
+                                    </div>
+                                    <div
+                                      *ngIf="
+                                        data.latest_data >= '1.6' &&
+                                        data.latest_data <= '2'
+                                      "
+                                    >
+                                      <span
+                                        class="
+                                          p-1.5
+                                          text-xs
+                                          font-medium
+                                          uppercase
+                                          tracking-wider
+                                          text-black
+                                          bg-high
+                                          rounded-lg
+                                        "
+                                      >
+                                        High (1.6m +)
+                                      </span>
+                                    </div>
+                                  </td>
+                                </tr>
+                              </tbody>
+                            </table>
+                          </div>
+                          <noah-pagination
+                            class="hidden md:block"
+                            [allPagesNumber]="allPages"
+                            (changePage)="onPageChange($event)"
+                          ></noah-pagination>
+                          <!-- MOBILE VIEW -->
+                          <div
+                            class="
+                              z-10
+                              pl-2
+                              h-16
+                              w-36
+                              flex flex-row
+                              py-2
+                              md:hidden
+                            "
+                          >
+                            <div class="p-2">
+                              <div class="dropdown inline-block relative">
+                                <button
+                                  class="
+                                    bg-gray-200
+                                    text-gray-800
+                                    font-semibold
+                                    py-1
+                                    px-1
+                                    ml-2
+                                    rounded
+                                    inline-flex
+                                    items-center
+                                    hover:bg-gray-200
+                                    focus:outline-none
+                                    focus:ring-2
+                                    focus:ring-gray-600
+                                    focus:ring-opacity-50
+                                  "
+                                >
+                                  Sort By:
+                                </button>
+                                <ul
+                                  class="
+                                    dropdown-menu
+                                    z-50
+                                    rounded-lg
+                                    drop-shadow-xl
+                                    bg-white
+                                    left-20
+                                    top-0
+                                    absolute
+                                    hidden
+                                    text-sm text-gray-700
+                                    w-32
+                                    h-48
+                                    overflow-y-auto
+                                  "
+                                >
+                                  <li class="w-32" *ngFor="let col of columns">
+                                    <a
+                                      class="
+                                        rounded-lg
+                                        block
+                                        px-4
+                                        py-2
+                                        text-sm
+                                        leading-5
+                                        text-gray-700
+                                        transition
+                                        duration-150
+                                        ease-in-out
+                                        hover:bg-gray-100
+                                        focus:outline-none focus:bg-gray-100
+                                      "
+                                      (click)="sortedColumn = col.key"
+                                      role="button"
+                                      >{{ col.mobileHeader }}</a
+                                    >
+                                  </li>
+                                </ul>
+                              </div>
+                            </div>
+                          </div>
+
+                          <div
+                            class="
+                              items-center
+                              justify-center
+                              py-2
+                              px-3
+                              md:hidden
+                              grid grid-cols-1
+                              h-96
+                              overflow-y-auto
+                              sm:grid-cols-2
+                              gap-4
+                            "
+                          >
+                            <div
+                              class="
+                                md:w-96
+                                rounded-md
+                                drop-shadow-2xl
+                                py-4
+                                px-5
+                                w-full
+                                bg-white
+                              "
+                              *ngFor="
+                                let data of floodSummaryData
+                                  | sort: sortedColumn
+                                  | searchfilter: searchValue
+                              "
+                            >
+                              <h1
+                                class="
+                                  text-lg
+                                  font-bold
+                                  text-gray-800
+                                  leading-5
+                                  pt-2
+                                "
+                              >
+                                {{ data.name }}
+                              </h1>
+                              <div class="pt-2 relative">
+                                <div class="flex items-center justify-between">
+                                  <div class="flex items-center">
+                                    <div
+                                      class="w-2 h-2 rounded-full bg-blue-500"
+                                    ></div>
+                                    <span
+                                      class="
+                                        text-blue-500 text-xs
+                                        italic
+                                        font-normal
+                                        pl-1
+                                      "
+                                    >
+                                      {{
+                                        data.latest_date
+                                          | date: 'medium':'+0000'
+                                      }}
+                                    </span>
+                                  </div>
+                                </div>
+                                <p
+                                  class="
+                                    text-sm
+                                    leading-none
+                                    pt-2
+                                    text-gray-600
+                                    first
+                                    capitalize
+                                  "
+                                >
+                                  Sensor Type: {{ data.iot_type }}
+                                </p>
+                                <p
+                                  class="
+                                    text-xs
+                                    italic
+                                    pt-1
+                                    leading-3
+                                    text-gray-400
+                                  "
+                                >
+                                  Latest Data: {{ data.latest_data }}
+                                </p>
+                                <div
+                                  class="flex items-center justify-left"
+                                  *ngIf="
+                                    data.latest_data <= '0' ||
+                                    data.latest_data <= '0.5'
+                                  "
+                                >
+                                  <div
+                                    class="
+                                      text-yellow-400
+                                      bg-yellow-200
+                                      py-1
+                                      px-2
+                                      rounded
+                                      text-xs
+                                      leading-3
+                                      mt-2
+                                      pl-2
+                                    "
+                                  >
+                                    Low (0 - 0.5m)
+                                  </div>
+                                </div>
+                                <div
+                                  class="flex items-center justify-left"
+                                  *ngIf="
+                                    data.latest_data >= '0.6' ||
+                                    data.latest_data >= '1.5'
+                                  "
+                                >
+                                  <div
+                                    class="
+                                      text-yellow-600
+                                      bg-yellow-400
+                                      py-1
+                                      px-2
+                                      rounded
+                                      text-xs
+                                      leading-3
+                                      mt-2
+                                      pl-2
+                                    "
+                                  >
+                                    Medium (0.5 - 1.5m)
+                                  </div>
+                                </div>
+                                <div
+                                  class="flex items-center justify-left"
+                                  *ngIf="
+                                    data.latest_data >= '1.6' ||
+                                    data.latest_data >= '2'
+                                  "
+                                >
+                                  <div
+                                    class="
+                                      text-red-600
+                                      bg-red-400
+                                      py-1
+                                      px-2
+                                      rounded
+                                      text-xs
+                                      leading-3
+                                      mt-2
+                                      pl-2
+                                    "
+                                  >
+                                    High (1.5m +)
+                                  </div>
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+
+                          <!-- MOBILE VIEW -->
+                        </div>
+                      </ng-template>
+                    </div>
+                  </article>
+                  <!-- TAB SECTION FOR RAIN -->
+                  <article class="tab-rain">
+                    <input
+                      type="radio"
+                      name="tab-indicator"
+                      id="select-rain"
+                      class="tab-indicator"
+                    />
+                    <div class="tab-content">
+                      <ng-container *ngIf="loading; else dataSummaryRain">
+                        <div tabindex="0" class="justify-center">
+                          <div
+                            class="shadow-xl w-full z-10 overflow-hidden"
+                            style="max-width: 1000px"
+                          >
+                            <div class="md:flex w-full">
+                              <div class="w-full py-10 px-5 md:px-10">
+                                <div class="flex justify-center gap-x-4 mb-4">
+                                  <div
+                                    class="
+                                      flex
+                                      items-center
+                                      justify-center
+                                      bottom-0
+                                    "
+                                  >
+                                    <div
+                                      class="
+                                        w-14
+                                        h-14
+                                        border-t-4 border-b-4 border-black
+                                        rounded-full
+                                        animate-spin
+                                        absolute
+                                      "
+                                    ></div>
+                                    <img
+                                      src="assets/icons/logo-noah.svg"
+                                      class="w-10 h-10 animate-none"
+                                      fill="none"
+                                    />
+                                  </div>
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                      </ng-container>
+                      <ng-template #dataSummaryRain>
+                        <div class="mt-2">
+                          <div
+                            class="
+                              overflow-auto
+                              rounded-lg
+                              shadow
+                              hidden
+                              md:block
+                            "
+                          >
+                            <table class="w-full b-4">
+                              <thead
+                                class="bg-gray-50 border-b-2 border-gray-200"
+                              >
+                                <tr>
+                                  <th
+                                    class="
+                                      p-3
+                                      text-sm
+                                      font-semibold
+                                      tracking-wide
+                                      text-left
+                                    "
+                                    *ngFor="let col of columns"
+                                  >
+                                    <div
+                                      (click)="sortedColumn = col.key"
+                                      class="cursor-pointer inline-flex"
+                                    >
+                                      {{ col.header }}
+                                      <svg
+                                        xmlns="http://www.w3.org/2000/svg"
+                                        class="mr-1 h-5 w-5 text-left"
+                                        viewBox="0 0 20 20"
+                                        fill="currentColor"
+                                      >
+                                        <path
+                                          d="M3 3a1 1 0 000 2h11a1 1 0 100-2H3zM3 7a1 1 0 000 2h5a1 1 0 000-2H3zM3 11a1 1 0 100 2h4a1 1 0 100-2H3zM13 16a1 1 0 102 0v-5.586l1.293 1.293a1 1 0 001.414-1.414l-3-3a1 1 0 00-1.414 0l-3 3a1 1 0 101.414 1.414L13 10.414V16z"
+                                        />
+                                      </svg>
+                                    </div>
+                                  </th>
+                                </tr>
+                              </thead>
+                              <tbody class="divide-y divide-gray-100">
+                                <tr
+                                  class="hover:bg-gray-100 bg-white"
+                                  *ngFor="
+                                    let data of rainSummaryData
+                                      | sort: sortedColumn
+                                      | searchfilter: searchValue
+                                  "
+                                >
+                                  <td
+                                    class="
+                                      p-3
+                                      text-sm text-gray-700
+                                      whitespace-nowrap
+                                    "
+                                  >
+                                    {{ data.name }}
+                                  </td>
+                                  <td
+                                    class="
+                                      p-3
+                                      text-sm text-gray-700
+                                      whitespace-nowrap
+                                      first-letter:capitalize
+                                    "
+                                  >
+                                    {{ data.iot_type }}
+                                  </td>
+
+                                  <td
+                                    class="
+                                      p-3
+                                      text-sm text-gray-700
+                                      whitespace-nowrap
+                                    "
+                                  >
+                                    {{
+                                      data.latest_date | date: 'medium':'+0000'
+                                    }}
+                                  </td>
+
+                                  <td
+                                    class="
+                                      p-3
+                                      text-sm text-gray-700
+                                      whitespace-nowrap
+                                      text-center
+                                      justify-center
+                                    "
+                                  >
+                                    {{ data.latest_data }}
+                                  </td>
+
+                                  <td
+                                    class="
+                                      p-3
+                                      text-sm text-gray-700
+                                      whitespace-nowrap
+                                    "
+                                  >
+                                    <div
+                                      *ngIf="
+                                        data.latest_data <= '0' &&
+                                        data.latest_data <= '0.5'
+                                      "
+                                    >
+                                      <span
+                                        class="
+                                          p-1.5
+                                          text-xs
+                                          font-medium
+                                          uppercase
+                                          tracking-wider
+                                          text-black
+                                          bg-low
+                                          rounded-lg
+                                        "
+                                        >Low (0 - 0.5m)</span
+                                      >
+                                    </div>
+                                    <div
+                                      *ngIf="
+                                        data.latest_data >= '0.6' &&
+                                        data.latest_data >= '1.5'
+                                      "
+                                    >
+                                      <span
+                                        class="
+                                          p-1.5
+                                          text-xs
+                                          font-medium
+                                          uppercase
+                                          tracking-wider
+                                          text-black
+                                          bg-medium
+                                          rounded-lg
+                                        "
+                                        >Medium (0.6 - 1.5m)</span
+                                      >
+                                    </div>
+                                    <div
+                                      *ngIf="
+                                        data.latest_data >= '1.6' &&
+                                        data.latest_data <= '2'
+                                      "
+                                    >
+                                      <span
+                                        class="
+                                          p-1.5
+                                          text-xs
+                                          font-medium
+                                          uppercase
+                                          tracking-wider
+                                          text-black
+                                          bg-high
+                                          rounded-lg
+                                        "
+                                      >
+                                        High (1.6m +)
+                                      </span>
+                                    </div>
+                                  </td>
+                                </tr>
+                              </tbody>
+                            </table>
+                          </div>
+                          <noah-pagination
+                            class="hidden md:block"
+                            [allPagesNumber]="allPages"
+                            (changePage)="onPageChange($event)"
+                          ></noah-pagination>
+                          <!-- MOBILE VIEW -->
+                          <div
+                            class="
+                              z-10
+                              pl-2
+                              h-16
+                              w-36
+                              flex flex-row
+                              py-2
+                              md:hidden
+                            "
+                          >
+                            <div class="p-2">
+                              <div class="dropdown inline-block relative">
+                                <button
+                                  class="
+                                    bg-gray-200
+                                    text-gray-800
+                                    font-semibold
+                                    py-1
+                                    px-1
+                                    ml-2
+                                    rounded
+                                    inline-flex
+                                    items-center
+                                    hover:bg-gray-200
+                                    focus:outline-none
+                                    focus:ring-2
+                                    focus:ring-gray-600
+                                    focus:ring-opacity-50
+                                  "
+                                >
+                                  Sort By:
+                                </button>
+                                <ul
+                                  class="
+                                    dropdown-menu
+                                    z-50
+                                    rounded-lg
+                                    drop-shadow-xl
+                                    bg-white
+                                    left-20
+                                    top-0
+                                    absolute
+                                    hidden
+                                    text-sm text-gray-700
+                                    w-32
+                                    h-48
+                                    overflow-y-auto
+                                  "
+                                >
+                                  <li class="w-32" *ngFor="let col of columns">
+                                    <a
+                                      class="
+                                        rounded-lg
+                                        block
+                                        px-4
+                                        py-2
+                                        text-sm
+                                        leading-5
+                                        text-gray-700
+                                        transition
+                                        duration-150
+                                        ease-in-out
+                                        hover:bg-gray-100
+                                        focus:outline-none focus:bg-gray-100
+                                      "
+                                      (click)="sortedColumn = col.key"
+                                      role="button"
+                                      >{{ col.mobileHeader }}</a
+                                    >
+                                  </li>
+                                </ul>
+                              </div>
+                            </div>
+                          </div>
+
+                          <div
+                            class="
+                              items-center
+                              justify-center
+                              py-2
+                              px-3
+                              md:hidden
+                              grid grid-cols-1
+                              h-96
+                              overflow-y-auto
+                              sm:grid-cols-2
+                              gap-4
+                            "
+                          >
+                            <div
+                              class="
+                                md:w-96
+                                rounded-md
+                                drop-shadow-2xl
+                                py-4
+                                px-5
+                                w-full
+                                bg-white
+                              "
+                              *ngFor="
+                                let data of rainSummaryData
+                                  | sort: sortedColumn
+                                  | searchfilter: searchValue
+                              "
+                            >
+                              <h1
+                                class="
+                                  text-lg
+                                  font-bold
+                                  text-gray-800
+                                  leading-5
+                                  pt-2
+                                "
+                              >
+                                {{ data.name }}
+                              </h1>
+                              <div class="pt-2 relative">
+                                <div class="flex items-center justify-between">
+                                  <div class="flex items-center">
+                                    <div
+                                      class="w-2 h-2 rounded-full bg-blue-500"
+                                    ></div>
+                                    <span
+                                      class="
+                                        text-blue-500 text-xs
+                                        italic
+                                        font-normal
+                                        pl-1
+                                      "
+                                    >
+                                      {{
+                                        data.latest_date
+                                          | date: 'medium':'+0000'
+                                      }}
+                                    </span>
+                                  </div>
+                                </div>
+                                <p
+                                  class="
+                                    text-sm
+                                    leading-none
+                                    pt-2
+                                    text-gray-600
+                                    first
+                                    capitalize
+                                  "
+                                >
+                                  Sensor Type: {{ data.iot_type }}
+                                </p>
+                                <p
+                                  class="
+                                    text-xs
+                                    italic
+                                    pt-1
+                                    leading-3
+                                    text-gray-400
+                                  "
+                                >
+                                  Latest Data: {{ data.latest_data }}
+                                </p>
+                                <div
+                                  class="flex items-center justify-left"
+                                  *ngIf="
+                                    data.latest_data <= '0' ||
+                                    data.latest_data <= '0.5'
+                                  "
+                                >
+                                  <div
+                                    class="
+                                      text-yellow-400
+                                      bg-yellow-200
+                                      py-1
+                                      px-2
+                                      rounded
+                                      text-xs
+                                      leading-3
+                                      mt-2
+                                      pl-2
+                                    "
+                                  >
+                                    Low (0 - 0.5m)
+                                  </div>
+                                </div>
+                                <div
+                                  class="flex items-center justify-left"
+                                  *ngIf="
+                                    data.latest_data >= '0.6' ||
+                                    data.latest_data >= '1.5'
+                                  "
+                                >
+                                  <div
+                                    class="
+                                      text-yellow-600
+                                      bg-yellow-400
+                                      py-1
+                                      px-2
+                                      rounded
+                                      text-xs
+                                      leading-3
+                                      mt-2
+                                      pl-2
+                                    "
+                                  >
+                                    Medium (0.5 - 1.5m)
+                                  </div>
+                                </div>
+                                <div
+                                  class="flex items-center justify-left"
+                                  *ngIf="
+                                    data.latest_data >= '1.6' ||
+                                    data.latest_data >= '2'
+                                  "
+                                >
+                                  <div
+                                    class="
+                                      text-red-600
+                                      bg-red-400
+                                      py-1
+                                      px-2
+                                      rounded
+                                      text-xs
+                                      leading-3
+                                      mt-2
+                                      pl-2
+                                    "
+                                  >
+                                    High (1.5m +)
+                                  </div>
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+
+                          <!-- MOBILE VIEW -->
+                        </div>
+                      </ng-template>
+                    </div>
+                  </article>
+                </section>
               </div>
             </div>
           </div>

--- a/src/app/shared/components/summary/summary.component.html
+++ b/src/app/shared/components/summary/summary.component.html
@@ -20,7 +20,7 @@
       focus:ring-opacity-50
       border-2
     "
-    (click)="viewSummary()"
+    (click)="viewSummary(pk)"
   >
     View Data Summary
   </button>

--- a/src/app/shared/components/summary/summary.component.scss
+++ b/src/app/shared/components/summary/summary.component.scss
@@ -1,3 +1,72 @@
 .dropdown:hover .dropdown-menu {
   display: block;
 }
+// navigation / menu
+nav {
+  margin: 0 0 0.75em;
+  padding: 0.75em;
+  border-bottom: 1px solid #717073;
+
+  ul {
+    list-style: none;
+    overflow: hidden;
+    padding: 0;
+    margin: 0;
+  }
+
+  li {
+    float: left;
+    position: relative;
+
+    + li {
+      border-left: 1px solid #717073;
+      margin-left: 1em;
+      padding-left: 1em;
+    }
+  }
+  .sensor-item > .active > li {
+    color: #fd8a02;
+  }
+
+  .tab-navigation > .active > label {
+    color: #fd8a02;
+  }
+
+  label {
+    cursor: pointer;
+
+    &:hover {
+      color: #fd8a02;
+    }
+  }
+  label[tabindex]:focus {
+    color: #fd8a02;
+  }
+}
+
+// hiding the indicators
+input.tab-indicator {
+  // don't use "display: none" - triggering the inputs via label won't work anymore
+  opacity: 0;
+  visibility: hidden;
+  position: absolute;
+}
+
+// containers / content
+.tab-content {
+  display: none;
+
+  input.tab-indicator:checked + & {
+    display: block;
+  }
+}
+// dummy-hightlighting of tab-contents
+.tab-all strong {
+  color: #fd8a02;
+}
+.tab-flood strong {
+  color: #4cb016;
+}
+.tab-rain strong {
+  color: #01669a;
+}

--- a/src/app/shared/components/summary/summary.component.ts
+++ b/src/app/shared/components/summary/summary.component.ts
@@ -1,26 +1,10 @@
-import { Component, OnInit, Input } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import {
   QcSensorService,
   SummaryItem,
 } from '@features/noah-playground/services/qc-sensor.service';
-import {
-  Observable,
-  of,
-  pipe,
-  Subject,
-  Subscription,
-  interval,
-  concat,
-  timer,
-} from 'rxjs';
-import {
-  first,
-  tap,
-  startWith,
-  switchMap,
-  take,
-  finalize,
-} from 'rxjs/operators';
+import { Observable, Subscription, timer } from 'rxjs';
+import { first } from 'rxjs/operators';
 
 @Component({
   selector: 'noah-summary',
@@ -86,7 +70,7 @@ export class SummaryComponent implements OnInit {
 
   ngOnInit(): void {}
 
-  async viewSummary() {
+  async viewSummary(pk: number) {
     if (this.loading) {
       return;
     }
@@ -100,7 +84,7 @@ export class SummaryComponent implements OnInit {
         .toPromise();
 
       const res: any = await this.qcSensorService
-        .getQcSensorData(this.pk)
+        .getIotSummarySensorData(pk)
         .pipe(first())
         .toPromise();
       const dataArr = res.results.map((a) => {
@@ -160,7 +144,7 @@ export class SummaryComponent implements OnInit {
       }
 
       this.subscription = this.everyFiveSeconds.subscribe(() => {
-        this.viewSummary(); //auto refresh data every 1 minute
+        this.viewSummary(pk); //auto refresh data every 1 minute
       });
       newArr.sort((a, b) => (a.latest_date > b.latest_date ? -1 : 1));
       floodSensor.sort((a, b) => (a.latest_date > b.latest_date ? -1 : 1));

--- a/src/app/shared/components/summary/summary.component.ts
+++ b/src/app/shared/components/summary/summary.component.ts
@@ -37,6 +37,15 @@ export class SummaryComponent implements OnInit {
   pk: number;
   summaryData: SummaryItem[] = [];
   fetchedData: SummaryItem[] = [];
+
+  floodSummaryData: SummaryItem[] = [];
+  floodFetchedData: SummaryItem[] = [];
+  activeFloodSensor: number;
+
+  rainSummaryData: SummaryItem[] = [];
+  rainFetchedData: SummaryItem[] = [];
+  rainActiveSensor: number;
+
   searchValue: string;
 
   itemsPerPage: number = 10;
@@ -70,8 +79,8 @@ export class SummaryComponent implements OnInit {
     },
     {
       key: 'critical_level',
-      header: 'CRITICAL LEVEL',
-      mobileHeader: 'Critical Level',
+      header: 'LEVEL',
+      mobileHeader: 'Level',
     },
   ];
 
@@ -111,6 +120,7 @@ export class SummaryComponent implements OnInit {
             pk: a.properties.pk,
           };
         });
+
       const totalSensor = response.features.map((a) => {
         return;
       });
@@ -124,15 +134,49 @@ export class SummaryComponent implements OnInit {
           }
         }
       }
+
+      const rainSensor = [];
+      for (let i = 0; i < locationArr.length; i++) {
+        for (let j = 0; j < dataArr.length; j++) {
+          if (locationArr[i].pk == dataArr[j].iot_sensor) {
+            if (locationArr[i].iot_type == 'rain') {
+              rainSensor.push({ ...locationArr[i], ...dataArr[j] });
+              break;
+            }
+          }
+        }
+      }
+
+      const floodSensor = [];
+      for (let i = 0; i < locationArr.length; i++) {
+        for (let j = 0; j < dataArr.length; j++) {
+          if (locationArr[i].pk == dataArr[j].iot_sensor) {
+            if (locationArr[i].iot_type == 'flood') {
+              floodSensor.push({ ...locationArr[i], ...dataArr[j] });
+              break;
+            }
+          }
+        }
+      }
+
       this.subscription = this.everyFiveSeconds.subscribe(() => {
         this.viewSummary(); //auto refresh data every 1 minute
       });
       newArr.sort((a, b) => (a.latest_date > b.latest_date ? -1 : 1));
+      floodSensor.sort((a, b) => (a.latest_date > b.latest_date ? -1 : 1));
+      rainSensor.sort((a, b) => (a.latest_date > b.latest_date ? -1 : 1));
+
       this.fetchedData = newArr;
+      this.floodFetchedData = floodSensor;
+      this.rainFetchedData = rainSensor;
       this.onPageChange();
       this.allPages = Math.ceil(this.fetchedData.length / this.itemsPerPage);
+
+      //count numbers
       this.activeSensor = newArr.length;
       this.total = totalSensor.length;
+      this.rainActiveSensor = rainSensor.length;
+      this.activeFloodSensor = floodSensor.length;
     } catch (error) {
       this.summaryModal = false;
       this.loading = !this.loading;
@@ -155,5 +199,7 @@ export class SummaryComponent implements OnInit {
     const startItem = (page - 1) * this.itemsPerPage;
     const endItem = page * this.itemsPerPage;
     this.summaryData = this.fetchedData.slice(startItem, endItem);
+    this.floodSummaryData = this.floodFetchedData.slice(startItem, endItem);
+    this.rainSummaryData = this.rainFetchedData.slice(startItem, endItem);
   }
 }


### PR DESCRIPTION
# Description 
- added tab navigation for different type of sensor
- added hover label for rain and flood sensor

# Screenshot
![image](https://user-images.githubusercontent.com/62271587/199407281-ed46d77b-c85e-41fd-94ae-445826bbe8db.png)

![image](https://user-images.githubusercontent.com/62271587/199407332-40ccb40b-3daf-4e18-84e6-dec62c456c28.png)

![image](https://user-images.githubusercontent.com/62271587/199407377-f7c0b8e8-cf07-439e-8f1e-412871640f91.png)
