### PR TITLE
feat(qc-iot): added unit for iot dot, KYH legend

### DIFF
--- a/src/app/features/know-your-hazards/components/map-kyh/map-kyh.component.html
+++ b/src/app/features/know-your-hazards/components/map-kyh/map-kyh.component.html
@@ -5,3 +5,103 @@
   [selectedStyle]="mapStyle"
   (selectedStyleChange)="switchMapStyle($event)"
 ></noah-change-style-button>
+
+<button
+  class="
+    opacity-80
+    bg-white
+    text-gray-800
+    font-semibold
+    py-1
+    px-1
+    ml-2
+    flex
+    items-end
+    absolute
+    justify-end
+    bottom-8
+    right-0
+    rounded
+    hover:bg-gray-200
+    focus:outline-none focus:ring-2 focus:ring-gray-600 focus:ring-opacity-50
+    mr-2
+    text-xs
+  "
+  (click)="openLegend()"
+  *ngIf="btnLegend"
+>
+  Hazard Level
+</button>
+
+<div class="" *ngIf="kyhLegend">
+  <div class="w-full flex items-end absolute justify-end bottom-8 pr-2">
+    <div
+      class="
+        xl:w-64
+        lg:w-1/4
+        md:w-2/5
+        flex flex-col
+        items-center
+        py-2
+        md:py-4
+        bg-gradient-to-r
+        p-2
+        from-white
+        to-white
+        rounded-md
+        opacity-75
+      "
+    >
+      <div
+        class="
+          cursor-pointer
+          absolute
+          top-0
+          right-0
+          mr-3
+          dark:text-gray-100
+          hover:dark:text-gray-100
+          text-gray-600
+          transition
+          duration-150
+          ease-in-out
+        "
+        (click)="openLegend()"
+      >
+        <span class="text-3xl">-</span>
+      </div>
+
+      <div class="w-full flex items-center justify-center">
+        <div class="flex flex-col items-center">
+          <p
+            class="
+              text-xs
+              sm:text-xs
+              md:text-base
+              font-semibold
+              text-center text-black
+            "
+          >
+            Hazard Level
+          </p>
+        </div>
+      </div>
+      <div class="mt-2 space-x-4 flex p-1">
+        <div class="flex items-center">
+          <div class="xl:w-6 xl:h-6 h-2 w-2 bg-low"></div>
+          <span class="text-low text-xs italic font-normal pl-1">Low</span>
+        </div>
+        <div class="flex items-center">
+          <div class="xl:w-6 xl:h-6 h-2 w-2 bg-medium"></div>
+          <span class="text-medium text-xs italic font-normal pl-1"
+            >Medium</span
+          >
+        </div>
+        <div class="flex items-center">
+          <div class="xl:w-6 xl:h-6 h-2 w-2 bg-high"></div>
+          <span class="text-high text-xs italic font-normal pl-1">High</span>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/src/app/features/know-your-hazards/components/map-kyh/map-kyh.component.html
+++ b/src/app/features/know-your-hazards/components/map-kyh/map-kyh.component.html
@@ -11,7 +11,7 @@
     opacity-80
     bg-white
     text-gray-800
-    font-semibold
+    font-bold
     py-1
     px-1
     ml-2
@@ -25,81 +25,71 @@
     hover:bg-gray-200
     focus:outline-none focus:ring-2 focus:ring-gray-600 focus:ring-opacity-50
     mr-2
-    text-xs
+    text-base
   "
   (click)="openLegend()"
   *ngIf="btnLegend"
 >
-  Hazard Level
+  Legend
 </button>
 
-<div class="" *ngIf="kyhLegend">
-  <div class="w-full flex items-end absolute justify-end bottom-8 pr-2">
-    <div
-      class="
-        xl:w-64
-        lg:w-1/4
-        md:w-2/5
-        flex flex-col
-        items-center
-        py-2
-        md:py-4
-        bg-gradient-to-r
-        p-2
-        from-white
-        to-white
-        rounded-md
-        opacity-75
-      "
-    >
+<div class="absolute bottom-8 mr-2 items-end right-0" *ngIf="kyhLegend">
+  <div class="flex items-center justify-center">
+    <div class="rounded shadow-lg py-3 px-4 bg-white bg-opacity-75">
       <div
         class="
           cursor-pointer
           absolute
           top-0
-          right-0
-          mr-3
+          -right-0.5
+          mt-2
+          mr-2
           dark:text-gray-100
-          hover:dark:text-gray-100
-          text-gray-600
+          hover:
+          dark:text-gray-100
+          text-black
           transition
           duration-150
           ease-in-out
         "
         (click)="openLegend()"
       >
-        <span class="text-3xl">-</span>
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="20"
+          height="20"
+          class="icon icon-tabler icon-tabler-x"
+          viewBox="0 0 700 700"
+          stroke-width="2.5"
+          stroke="currentColor"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+        >
+          <path d="M490 294H210a14 14 0 0 1 0-28h280a14 14 0 0 1 0 28z" />
+        </svg>
       </div>
+      <h1 class="text-sm font-bold leading-3 mt-3 text-gray-800">
+        Hazard Level
+      </h1>
+      <div class="">
+        <div class="flex items-center justify-between pt-3">
+          <div class="flex items-center">
+            <div class="xl:w-6 xl:h-6 h-2 w-2 bg-low"></div>
+            <p class="text-xs leading-3 text-low pl-2">Low</p>
+          </div>
+        </div>
+        <div class="flex items-center justify-between pt-3">
+          <div class="flex items-center">
+            <div class="xl:w-6 xl:h-6 h-2 w-2 bg-medium"></div>
 
-      <div class="w-full flex items-center justify-center">
-        <div class="flex flex-col items-center">
-          <p
-            class="
-              text-xs
-              sm:text-xs
-              md:text-base
-              font-semibold
-              text-center text-black
-            "
-          >
-            Hazard Level
-          </p>
+            <p class="text-xs leading-3 text-medium pl-2">Medium</p>
+          </div>
         </div>
-      </div>
-      <div class="mt-2 space-x-4 flex p-1">
-        <div class="flex items-center">
-          <div class="xl:w-6 xl:h-6 h-2 w-2 bg-low"></div>
-          <span class="text-low text-xs italic font-normal pl-1">Low</span>
-        </div>
-        <div class="flex items-center">
-          <div class="xl:w-6 xl:h-6 h-2 w-2 bg-medium"></div>
-          <span class="text-medium text-xs italic font-normal pl-1"
-            >Medium</span
-          >
-        </div>
-        <div class="flex items-center">
-          <div class="xl:w-6 xl:h-6 h-2 w-2 bg-high"></div>
-          <span class="text-high text-xs italic font-normal pl-1">High</span>
+        <div class="flex items-center justify-between pt-3">
+          <div class="flex items-center">
+            <div class="xl:w-6 xl:h-6 h-2 w-2 bg-high"></div>
+            <p class="text-xs leading-3 text-high pl-2">High</p>
+          </div>
         </div>
       </div>
     </div>

--- a/src/app/features/know-your-hazards/components/map-kyh/map-kyh.component.ts
+++ b/src/app/features/know-your-hazards/components/map-kyh/map-kyh.component.ts
@@ -29,6 +29,8 @@ export class MapKyhComponent implements OnInit {
   geolocateControl!: GeolocateControl;
   centerMarker!: Marker;
   mapStyle: MapStyle = 'terrain';
+  kyhLegend: boolean = true;
+  btnLegend: boolean = false;
 
   private _unsub = new Subject();
   private _changeStyle = new Subject();
@@ -239,6 +241,11 @@ export class MapKyhComponent implements OnInit {
       center: this.kyhService.currentCoords,
       attributionControl: false,
     });
+  }
+
+  openLegend() {
+    this.btnLegend = !this.btnLegend;
+    this.kyhLegend = !this.kyhLegend;
   }
 
   async initMarkers() {

--- a/src/app/features/noah-playground/components/map-playground/map-playground.component.ts
+++ b/src/app/features/noah-playground/components/map-playground/map-playground.component.ts
@@ -426,7 +426,6 @@ export class MapPlaygroundComponent implements OnInit, OnDestroy {
       },
       rangeSelector: {
         enabled: true,
-        allButtonsEnabled: true,
         inputDateFormat: '%b %e, %Y %H:%M',
         buttons: [
           {
@@ -444,7 +443,6 @@ export class MapPlaygroundComponent implements OnInit, OnDestroy {
             text: 'All',
           },
         ],
-        selected: 0,
         buttonTheme: {
           width: 60,
         },
@@ -527,8 +525,13 @@ export class MapPlaygroundComponent implements OnInit, OnDestroy {
     const qcSensorChartOpts = {
       data: response.results,
       qcSensorType,
+      pk,
     };
+
     this.qcSensorChartService.qcShowChart(chart, qcSensorChartOpts);
+    setTimeout(function () {
+      chart.rangeSelector.clickButton(0);
+    }, 3500);
   }
 
   initQCCritFac() {

--- a/src/app/features/noah-playground/components/map-playground/map-playground.component.ts
+++ b/src/app/features/noah-playground/components/map-playground/map-playground.component.ts
@@ -322,10 +322,19 @@ export class MapPlaygroundComponent implements OnInit, OnDestroy {
               'text-allow-overlap': true,
               'text-optional': true,
               'text-font': ['Open Sans Semibold', 'Arial Unicode MS Bold'],
-              'text-size': 9,
-              'text-offset': [0, 1.25],
+              'text-size': 13,
+              'text-offset': [0, 1],
               'text-anchor': 'top',
-              'text-letter-spacing': 0.08,
+              'text-letter-spacing': 0.05,
+              visibility: 'none',
+            },
+            paint: {
+              'text-color': [
+                'case',
+                ['==', ['get', 'iot_type'], 'rain'],
+                '#06b9e6',
+                '#519259',
+              ],
             },
             minzoom: minZoom,
           });
@@ -341,18 +350,14 @@ export class MapPlaygroundComponent implements OnInit, OnDestroy {
                 'circle-opacity',
                 +(groupShown && soloShown)
               );
-              this.map.setLayoutProperty(
-                qcTextID,
-                'visibility',
-                groupShown && soloShown ? 'visible' : 'none'
-              );
-              this.map.on('zoomend', () => {
+              if (groupShown && soloShown) {
                 if (this.map.getZoom() < minZoom) {
-                  this.map.setLayoutProperty(qcTextID, 'visibility', 'none');
-                } else {
                   this.map.setLayoutProperty(qcTextID, 'visibility', 'visible');
                 }
-              });
+                this.map.setLayoutProperty(qcTextID, 'visibility', 'visible');
+              } else {
+                this.map.setLayoutProperty(qcTextID, 'visibility', 'none');
+              }
             });
 
           this.pgService.setQuezonCitySensorTypeFetched(qcSensorType, true);

--- a/src/app/features/noah-playground/components/map-playground/map-playground.component.ts
+++ b/src/app/features/noah-playground/components/map-playground/map-playground.component.ts
@@ -310,14 +310,18 @@ export class MapPlaygroundComponent implements OnInit, OnDestroy {
             },
             layout: {
               'text-field': [
-                'concat',
-                ['get', 'latest_data'],
-                [
-                  'case',
-                  ['!=', ['get', 'latest_data'], null],
-                  '',
-                  ['concat', ['get', 'latest_data'], 'Unavailable'],
-                ],
+                // 'concat',
+                // ['get', 'latest_data'],
+                // [
+                //   'case',
+                //   ['!=', ['get', 'latest_data'], null],
+                //   '',
+                //   ['concat', ['get', 'latest_data'], 'Unavailable'],
+                // ],
+                'case',
+                ['==', ['get', 'iot_type'], 'rain'],
+                ['concat', ['get', 'latest_data'], 'mm'],
+                ['concat', ['get', 'latest_data'], 'm'],
               ],
               'text-allow-overlap': true,
               'text-optional': true,

--- a/src/app/features/noah-playground/services/qc-sensor.service.ts
+++ b/src/app/features/noah-playground/services/qc-sensor.service.ts
@@ -36,8 +36,10 @@ export class QcSensorService {
   constructor(private http: HttpClient) {}
 
   getQcSensors(type: QuezonCitySensorType) {
-    const param = type ? `?iot_type=${type}` : '';
-    return this.http.get(`${this.QCBASE_URL}/api/iot-sensors/${param}`);
+    const param = type ? `iot_type=${type}` : '';
+    return this.http.get(
+      `${this.QCBASE_URL}/api/iot-sensors/?municity=quezon_city&${param}`
+    );
   }
 
   getQcCriticalFacilities() {
@@ -45,7 +47,9 @@ export class QcSensorService {
   }
 
   getLocation() {
-    return this.http.get(`${this.QCBASE_URL}/api/iot-sensors/?format=json`);
+    return this.http.get(
+      `${this.QCBASE_URL}/api/iot-sensors/?format=json&municity=quezon_city`
+    );
   }
 
   getQcSensorData(

--- a/src/app/shared/components/summary/summary.component.html
+++ b/src/app/shared/components/summary/summary.component.html
@@ -369,9 +369,12 @@
                         >
                           <table class="w-full">
                             <thead class="bg-blue-200">
-                              <tr>
+                              <tr class="text-left">
                                 <th
                                   class="
+                                    top-0
+                                    border-b border-gray-200
+                                    bg-blue-200
                                     p-2
                                     text-xs
                                     tracking-wide
@@ -388,7 +391,7 @@
                                     {{ col.header }}
                                     <svg
                                       xmlns="http://www.w3.org/2000/svg"
-                                      class="mr-1 h-5 w-5 text-left"
+                                      class="mr-1 h-4 w-4 text-left"
                                       viewBox="0 0 20 20"
                                       fill="currentColor"
                                     >

--- a/src/app/shared/components/summary/summary.component.html
+++ b/src/app/shared/components/summary/summary.component.html
@@ -304,57 +304,6 @@
                   </li>
                 </ul>
               </nav>
-              <!-- <nav class="tab-navigation bg-blue-50">                
-                <ul class="tab-navigation">
-                  <li class="nav-item">
-                    <label
-                      class="
-                        nav-link
-                        text-primary
-                        sm:text-base
-                        text-[10px]
-                        uppercase
-                      "
-                      tabindex="1"
-                      for="select-all"
-                      >All</label
-                    >
-                  </li>
-                  <li class="nav-item">
-                    <label
-                      class="
-                        nav-link
-                        text-primary
-                        sm:text-base
-                        text-[10px]
-                        uppercase
-                      "
-                      tabindex="1"
-                      for="select-flood"
-                      >Flood Sensor<span class="text-black">
-                        ({{ activeFloodSensor }})</span
-                      ></label
-                    >
-                  </li>
-                  <li class="nav-item">
-                    <label
-                      class="
-                        nav-link
-                        text-primary
-                        sm:text-base
-                        text-[10px]
-                        uppercase
-                      "
-                      tabindex="1"
-                      for="select-rain"
-                      >Rainfall Sensor<span class="text-black">
-                        ({{ activeRainSensor }})</span
-                      ></label
-                    >
-                  </li>
-                </ul>
-              </nav> -->
-
               <section>
                 <!-- TAB SECTION FOR ALL -->
                 <article class="tab-all">
@@ -414,7 +363,9 @@
                             shadow
                             hidden
                             lg:block
+                            overflow-y-auto
                           "
+                          style="height: 405px"
                         >
                           <table class="w-full">
                             <thead class="bg-blue-200">
@@ -422,10 +373,11 @@
                                 <th
                                   class="
                                     p-2
-                                    text-sm
-                                    font-semibold
+                                    text-xs
                                     tracking-wide
                                     text-left
+                                    font-extrabold
+                                    sticky
                                   "
                                   *ngFor="let col of columns"
                                 >

--- a/src/app/shared/components/summary/summary.component.ts
+++ b/src/app/shared/components/summary/summary.component.ts
@@ -120,13 +120,14 @@ export class SummaryComponent implements OnInit {
           status: a.status,
         };
       });
+
       const totalSensor = response.features.map((a) => {
         return;
       });
 
-      const activeSensors = res.results.map((a) => {
+      const activeSensors = response.features.map((a) => {
         return {
-          status: a.status,
+          status: a.properties.status,
         };
       });
 


### PR DESCRIPTION
# Description
- added unit for iot dot and `latest_data` per sensor 
- From BE they removed unit `latest_data`
- KYH legend UI and opacity
- QC iot summary dashboard table with overflow (scroll Y axis)
- fixed table header when scrolling
- changed endpoint for quezon city in `qc-iot services`
- changed total and active sensor count for iot

# Screenshots
![image](https://user-images.githubusercontent.com/62271587/218024677-8f229276-7540-49cb-ad8c-75fdbc251cc7.png)

![image](https://user-images.githubusercontent.com/62271587/218024711-3bc84dfa-390f-48fa-a463-0000825e4602.png)

![image](https://user-images.githubusercontent.com/62271587/218024880-fa2a604a-01d4-476e-8c32-0668072d4e6e.png)
