### PR TITLE
feat(qc-iot): chart default to all

### DIFF
--- a/src/app/features/noah-playground/components/map-playground/map-playground.component.ts
+++ b/src/app/features/noah-playground/components/map-playground/map-playground.component.ts
@@ -582,9 +582,6 @@ export class MapPlaygroundComponent implements OnInit, OnDestroy {
     };
 
     this.qcSensorChartService.qcShowChart(chart, qcSensorChartOpts);
-    setTimeout(function () {
-      chart.rangeSelector.clickButton(0);
-    }, 3500);
   }
 
   initQCCritFac() {


### PR DESCRIPTION
# Description
- remove 1 day default when data is loaded in chart
- back in `All` default when chart popped out