### PR TITLE
fix(noah-studio): change default color for hazard layers

### DIFF
--- a/src/app/features/home/components/footer/footer.component.html
+++ b/src/app/features/home/components/footer/footer.component.html
@@ -216,7 +216,7 @@
           </a>
           <a
             class="flex items-center hover:text-blue-600 no-underline"
-            href="mailto:resilience.institute@up.edu.ph"
+            href="mailto:resilience.institute at up.edu.ph"
             target="_blank"
           >
             <svg

--- a/src/app/features/home/components/footer/footer.component.html
+++ b/src/app/features/home/components/footer/footer.component.html
@@ -216,7 +216,7 @@
           </a>
           <a
             class="flex items-center hover:text-blue-600 no-underline"
-            href="mailto:resilience.institute at up.edu.ph"
+            href="mailto: resilience.institute at up.edu.ph"
             target="_blank"
           >
             <svg

--- a/src/app/features/noah-playground/components/contour-maps/contour-maps.component.ts
+++ b/src/app/features/noah-playground/components/contour-maps/contour-maps.component.ts
@@ -9,14 +9,7 @@ import { Observable } from 'rxjs';
   styleUrls: ['./contour-maps.component.scss'],
 })
 export class ContourMapsComponent implements OnInit {
-  contourMaps: ContourMapType[] = [
-    '1hr',
-    '3hr',
-    '6hr',
-    '12hr',
-    '24hr',
-    '24hr-lapse',
-  ];
+  contourMaps: ContourMapType[] = ['1hr', '3hr', '6hr', '12hr', '24hr'];
 
   expanded$: Observable<boolean>;
   selectedContourMap$: Observable<ContourMapType>;

--- a/src/app/features/noah-playground/store/noah-playground.store.ts
+++ b/src/app/features/noah-playground/store/noah-playground.store.ts
@@ -32,13 +32,7 @@ export type LandslideHazards =
   | 'debris-flow'
   | 'unstable-slopes-maps';
 
-export type ContourMapType =
-  | '1hr'
-  | '3hr'
-  | '6hr'
-  | '12hr'
-  | '24hr'
-  | '24hr-lapse';
+export type ContourMapType = '1hr' | '3hr' | '6hr' | '12hr' | '24hr';
 
 export const WEATHER_SATELLITE_ARR = ['himawari', 'himawari-GSMAP'] as const;
 

--- a/src/app/features/noah-playground/store/noah-playground.store.ts
+++ b/src/app/features/noah-playground/store/noah-playground.store.ts
@@ -182,7 +182,7 @@ const createInitialValue = (): NoahPlaygroundState => ({
       'landslide-hazard': {
         opacity: 85,
         color: 'noah-green',
-        shown: false,
+        shown: true,
       },
       // 'alluvial-fan-hazard': {
       //   opacity: 100,

--- a/src/app/features/noah-playground/store/noah-playground.store.ts
+++ b/src/app/features/noah-playground/store/noah-playground.store.ts
@@ -160,17 +160,17 @@ const createInitialValue = (): NoahPlaygroundState => ({
     levels: {
       'flood-return-period-5': {
         opacity: 85,
-        color: 'noah-red',
+        color: 'noah-blue',
         shown: false,
       },
       'flood-return-period-25': {
         opacity: 85,
-        color: 'noah-red',
+        color: 'noah-blue',
         shown: false,
       },
       'flood-return-period-100': {
         opacity: 85,
-        color: 'noah-red',
+        color: 'noah-blue',
         shown: true,
       },
     },
@@ -181,7 +181,7 @@ const createInitialValue = (): NoahPlaygroundState => ({
     levels: {
       'landslide-hazard': {
         opacity: 85,
-        color: 'noah-red',
+        color: 'noah-green',
         shown: false,
       },
       // 'alluvial-fan-hazard': {
@@ -191,12 +191,12 @@ const createInitialValue = (): NoahPlaygroundState => ({
       // },
       'debris-flow': {
         opacity: 85,
-        color: 'noah-red',
+        color: 'noah-violet',
         shown: false,
       },
       'unstable-slopes-maps': {
         opacity: 85,
-        color: 'noah-red',
+        color: 'noah-green',
         shown: false,
       },
     },


### PR DESCRIPTION
### Updates:

- Change default color for hazard layers (blue for flood, green for landslide, red for stormsurge)
- Change footer mail to address