### PR TITLE
fix(4as): exposure assessment sidebar expand and check at the same time

### DIFF
--- a/src/app/features/noah-playground/components/risk-assessment-group/risk-assessment-group.component.html
+++ b/src/app/features/noah-playground/components/risk-assessment-group/risk-assessment-group.component.html
@@ -1,5 +1,5 @@
 <div class="p-5 w-full bg-sidebar shadow-md hover:shodow-lg rounded-lg mt-6">
-  <div class="flex cursor-pointer select-none">
+  <div class="flex cursor-pointer select-none" (click)="toggleExpanded($event)">
     <label class="inline-flex items-center checkbox">
       <input
         type="checkbox"
@@ -123,7 +123,10 @@
       </button>
     </div>
   </div>
-  <div [ngClass]="(expanded$ | async) ? ' pt-5 ' : ' hidden '">
+  <div
+    *ngIf="isExpanded"
+    [ngClass]="(expanded$ | async) ? ' pt-5 ' : ' hidden '"
+  >
     <hr class="pb-4" />
     <div class="pl-2">
       <div class="items-center">

--- a/src/app/features/noah-playground/components/risk-assessment-group/risk-assessment-group.component.ts
+++ b/src/app/features/noah-playground/components/risk-assessment-group/risk-assessment-group.component.ts
@@ -24,7 +24,7 @@ export class RiskAssessmentGroupComponent implements OnInit {
   expanded$: Observable<boolean>;
   riskAssessmentPopuShown$: Observable<boolean>;
   shown$: Observable<boolean>;
-
+  expandedValue: boolean = false;
   initialRainOpacityValue: number = 80;
   initialPopuOpacityValue: number = 80;
 
@@ -34,6 +34,10 @@ export class RiskAssessmentGroupComponent implements OnInit {
   checkedShown = false;
 
   popuLegend = false;
+
+  get isExpanded(): boolean {
+    return this.expandedValue;
+  }
 
   constructor(
     private pgService: NoahPlaygroundService,
@@ -84,21 +88,34 @@ export class RiskAssessmentGroupComponent implements OnInit {
   toggleExpanded(event: Event) {
     event.stopPropagation();
     event.stopImmediatePropagation();
-    this.pgService.toggleRiskAssessmentGroupProperty('expanded');
+    this.expandedValue = !this.expandedValue;
+    this.pgService.toggleRiskAssessmentGroupProperty(
+      'expanded',
+      this.expandedValue
+    );
   }
 
   toggleShown(event: Event) {
     event.stopPropagation();
     event.stopImmediatePropagation();
     this.checkedShown = (event.target as HTMLInputElement).checked;
-    this.pgService.toggleRiskAssessmentGroupProperty('shown');
-    this.pgService.toggleRiskAssessmentGroupProperty('expanded');
     this.updateButtonEnabled();
-
+    this.expandedValue = true;
     if (!this.checkedShown) {
       this.modalService.closeBtnRiskAssessment();
       this.popuLegend = false;
       this.pgService.toggleAffectedPopulationVisibilityFalse();
+      this.pgService.toggleRiskAssessmentGroupProperty('shown', false);
+      this.pgService.toggleRiskAssessmentGroupProperty(
+        'expanded',
+        (this.expandedValue = false)
+      );
+    } else {
+      this.pgService.toggleRiskAssessmentGroupProperty('shown', true);
+      this.pgService.toggleRiskAssessmentGroupProperty(
+        'expanded',
+        this.expandedValue
+      );
     }
   }
 

--- a/src/app/features/noah-playground/services/noah-playground.service.ts
+++ b/src/app/features/noah-playground/services/noah-playground.service.ts
@@ -521,13 +521,17 @@ export class NoahPlaygroundService {
     this.store.patch({ volcanoes }, `Volcanoes ${property}, ${!currentValue}`);
   }
 
-  toggleRiskAssessmentGroupProperty(property: 'expanded' | 'shown') {
+  toggleRiskAssessmentGroupProperty(
+    property: 'expanded' | 'shown',
+    value: boolean
+  ) {
     const riskAssessment: RiskAssessmentGroupState = {
       ...this.store.state.riskAssessment,
     };
 
     const currentValue = riskAssessment[property];
-    riskAssessment[property] = !currentValue;
+    //riskAssessment[property] = !currentValue; remain this if ever we have changes
+    riskAssessment[property] = value;
     this.store.patch(
       { riskAssessment },
       `Risk Assessment ${property}, ${!currentValue}`


### PR DESCRIPTION
# Description
- checked and then expand the Exposure Assessment sidebar
- unchecked to close the expand
- still clickable the expand button and toggle it.


# Loom
https://www.loom.com/share/de95ac9664234440a6d76f1161dd8f3c?sid=ac6933a0-5d42-41f2-88f7-084dfc3c0c24