### PR TITLE
fix[weather-updates]: fix the opacity and routing behavior for weather updates both desktop and mobile

### DIFF
--- a/src/app/features/home/pages/landing-page/landing-page.component.ts
+++ b/src/app/features/home/pages/landing-page/landing-page.component.ts
@@ -76,28 +76,15 @@ export class LandingPageComponent implements OnInit {
       behavior: 'smooth',
     });
   }
-  weatherUpdate() {
-    //reset rainfall contour opacity to 100 for all types
-    ['1hr', '3hr', '6hr', '12hr', '24hr'].forEach((type) => {
-      this.wuService.setRainfallContourOpacity(100, type as any);
-    });
-    //disable typhoon track and weather satellite overlays
-    this.wuService.setTyphoonTrackVisibility(false);
-    this.wuService.setWeatherSatelliteVisibility(false);
-    this.wuService.setTemperatureVisibility(false);
+  weatherUpdate(): void {
+    this.wuService.activateRainfall();
   }
 
-  typhoonTrack() {
-    // Automatically enable typhoon track and himawari satellite when navigating from landing page
-    const selectedType = this.wuService.getSelectedRainfallContourType();
-    this.wuService.setRainfallContourOpacity(0, selectedType);
-    this.wuService.enableTyphoonTrackAndSatellite();
-    this.wuService.setTemperatureVisibility(false);
+  typhoonTrack(): void {
+    this.wuService.activateTyphoonTrack();
   }
 
-  temperature() {
-    this.wuService.enableTemperature();
-    this.wuService.setTyphoonTrackVisibility(false);
-    this.wuService.setWeatherSatelliteVisibility(false);
+  temperature(): void {
+    this.wuService.activateTemperature();
   }
 }

--- a/src/app/features/noah-playground/store/noah-playground.store.ts
+++ b/src/app/features/noah-playground/store/noah-playground.store.ts
@@ -650,8 +650,6 @@ const createInitialValue = (): NoahPlaygroundState => ({
   },
   lightning: {
     shown: false,
-  temperature: {
-    shown: true,
     expanded: false,
     selectedType: 'realtime-lightning',
     types: {

--- a/src/app/features/weather-updates/components/map-weather-updates/map-weather-updates.component.ts
+++ b/src/app/features/weather-updates/components/map-weather-updates/map-weather-updates.component.ts
@@ -394,12 +394,9 @@ export class MapWeatherUpdatesComponent implements OnInit, AfterViewInit {
           },
         });
 
-        const rainfallOpacity$ = this.wuService
-          .getRainfallContour$(rainfallContourType)
-          .pipe(
-            map((rainfall) => rainfall.opacity),
-            distinctUntilChanged()
-          );
+        const overlayOpacity$ = this.wuService.overlayOpacity$.pipe(
+          distinctUntilChanged()
+        );
 
         const selectedRainfallContour$ =
           this.wuService.selectedRainfallContourType$.pipe(
@@ -411,21 +408,18 @@ export class MapWeatherUpdatesComponent implements OnInit, AfterViewInit {
         );
 
         combineLatest([
-          rainfallOpacity$,
+          overlayOpacity$,
           selectedRainfallContour$,
           rainfallShown$,
         ])
           .pipe(takeUntil(this._unsub), takeUntil(this._changeStyle))
           .subscribe(
-            ([rainfallOpacity, selectedRainfallContour, rainfallShown]) => {
-              let opacity = +(
-                rainfallShown &&
-                rainfallOpacity &&
-                selectedRainfallContour === rainfallContourType
-              );
-              if (opacity) {
-                opacity = rainfallOpacity / 100;
-              }
+            ([overlayOpacity, selectedRainfallContour, rainfallShown]) => {
+              const opacity =
+                rainfallShown && selectedRainfallContour === rainfallContourType
+                  ? overlayOpacity / 100
+                  : 0;
+
               this.map.setPaintProperty(
                 rainfallContourType,
                 'raster-opacity',
@@ -509,24 +503,22 @@ export class MapWeatherUpdatesComponent implements OnInit, AfterViewInit {
             shareReplay(1)
           );
 
-        const temperatureOpacity$ = this.wuService
-          .getTemperature$(temperatureType)
-          .pipe(
-            map((temperature) => temperature.opacity),
-            distinctUntilChanged()
-          );
+        const overlayOpacity$ = this.wuService.overlayOpacity$.pipe(
+          distinctUntilChanged()
+        );
 
-        combineLatest([soloShown$, selectedTemperature$, temperatureOpacity$])
+        combineLatest([soloShown$, selectedTemperature$, overlayOpacity$])
           .pipe(takeUntil(this._unsub), takeUntil(this._changeStyle))
-          .subscribe(([soloShown, groupShown, temperatureOpacity]) => {
-            let newOpacity = +(soloShown && groupShown === temperatureType);
-            if (newOpacity) {
-              newOpacity = temperatureOpacity / 100;
-            }
+          .subscribe(([soloShown, selectedTemperature, overlayOpacity]) => {
+            const opacity =
+              soloShown && selectedTemperature === temperatureType
+                ? overlayOpacity / 100
+                : 0;
+
             this.map.setPaintProperty(
               temperatureType,
               'raster-opacity',
-              newOpacity
+              opacity
             );
           });
 

--- a/src/app/features/weather-updates/components/rainfall-contour-button/rainfall-contour-button.component.html
+++ b/src/app/features/weather-updates/components/rainfall-contour-button/rainfall-contour-button.component.html
@@ -380,9 +380,8 @@
             [min]="min"
             [max]="max"
             [step]="step"
-            [value]="initialValue"
             [formControl]="sliderCtrl"
-            (input)="changeOpacity($event)"
+            (input)="changeOpacity()"
           />
 
           <div class="flex justify-between text-xs text-gray-600 mx-1">

--- a/src/app/features/weather-updates/components/rainfall-contour-button/rainfall-contour-button.component.ts
+++ b/src/app/features/weather-updates/components/rainfall-contour-button/rainfall-contour-button.component.ts
@@ -125,12 +125,12 @@ export class RainfallContourButtonComponent implements OnInit {
   }
 
   selectRainfallContourType(type: RainfallContourTypes) {
-    this.router.navigateByUrl('/weather-updates/rainfall-contour');
+    if (!this.wuService.getTyphoonTrack().shown) {
+      this.router.navigateByUrl('/weather-updates/rainfall-contour');
+    }
     this.isTemperatureActive = false;
     this.activeRainfallContourType = type;
     this.wuService.selectRainfallContourType(type);
-    const selectedType = this.wuService.getSelectedRainfallContourType();
-    this.wuService.setRainfallContourOpacity(80, selectedType);
   }
 
   selectActiveRainfallContourType(type: RainfallContourTypes) {
@@ -155,19 +155,17 @@ export class RainfallContourButtonComponent implements OnInit {
     return `${label}`;
   }
 
-  changeOpacity(event: Event): void {
-    const input = event.target as HTMLInputElement;
-    const opacity = Number(input.value);
+  changeOpacity(): void {
+    const opacity = Number(this.sliderCtrl.value);
 
     if (this.isTemperatureActive) {
       this.wuService.setTemperatureOpacity(opacity, this.activeTemperatureType);
-      return;
+    } else {
+      this.wuService.setRainfallContourOpacity(
+        opacity,
+        this.activeRainfallContourType
+      );
     }
-
-    this.wuService.setRainfallContourOpacity(
-      opacity,
-      this.activeRainfallContourType
-    );
   }
   getMobileIcon(type: RainfallContourTypes): string {
     // e.g. 1hr -> 1hr.svg
@@ -204,16 +202,14 @@ export class RainfallContourButtonComponent implements OnInit {
    * Select temperature type (heat_index or max_temperature)
    */
   selectTemperatureType(tempType: TemperatureType): void {
-    this.router.navigateByUrl('/weather-updates/temperature');
-    this.wuService.enableTemperature();
-    const tempSelected = this.wuService.getTemperatureType();
-    this.wuService.setTemperatureOpacity(80, tempSelected);
+    if (!this.wuService.getTyphoonTrack().shown) {
+      this.router.navigateByUrl('/weather-updates/temperature');
+    }
+
     this.isTemperatureActive = true;
     this.activeTemperatureType = tempType;
+
     this.wuService.selectTemperatureType(tempType);
-    this.sliderCtrl.setValue(this.wuService.getTemperatureOpacity(tempType), {
-      emitEvent: false,
-    });
   }
 
   /**

--- a/src/app/features/weather-updates/components/typhoon-track-group/typhoon-track-group.component.ts
+++ b/src/app/features/weather-updates/components/typhoon-track-group/typhoon-track-group.component.ts
@@ -35,67 +35,64 @@ export class TyphoonTrackGroupComponent implements OnInit {
   }
 
   private autoEnableFeatures(): void {
-    if (this.router.url === '/weather-updates/typhoon-track') {
-      const typhoonTrack = this.wuService.getTyphoonTrack();
-      const weatherSatellite = this.wuService.getWeatherSatellites();
-      const selectedType = this.wuService.getSelectedRainfallContourType();
-      this.wuService.setRainfallContourOpacity(0, selectedType);
-      const tempType = this.wuService.getTemperatureType();
-      this.wuService.setTemperatureOpacity(0, tempType);
-
-      if (!typhoonTrack.shown || !weatherSatellite.shown) {
-        this.shown = true; // ✅ sync checkbox UI
-        this.wuService.enableTyphoonTrackAndSatellite();
-        this.wuService.triggerZoomToTyphoon();
-      }
-    } else if (this.router.url === '/weather-updates/rainfall-contour') {
-      const selectedType = this.wuService.getSelectedRainfallContourType();
-      this.wuService.setRainfallContourOpacity(80, selectedType);
-    } else if (this.router.url === '/weather-updates/temperature') {
-      this.wuService.enableTemperature();
-      const selectedType = this.wuService.getSelectedRainfallContourType();
-      this.wuService.setRainfallContourOpacity(0, selectedType);
+    if (!this.router.url.startsWith('/weather-updates')) {
+      return;
     }
+    const typhoonShown = this.wuService.getTyphoonTrack().shown;
+
+    switch (this.router.url) {
+      case '/weather-updates/typhoon-track':
+        if (!typhoonShown) {
+          this.wuService.activateTyphoonTrack();
+          this.wuService.triggerZoomToTyphoon();
+        }
+        break;
+
+      case '/weather-updates/rainfall-contour':
+        this.wuService.activateRainfall();
+
+        // Keep Typhoon checkbox in sync
+        this.shown = typhoonShown;
+        break;
+
+      case '/weather-updates/temperature':
+        this.wuService.activateTemperature();
+
+        // Keep Typhoon checkbox in sync
+        this.shown = typhoonShown;
+        break;
+
+      default:
+        // If Typhoon Track is off but URL is still /typhoon-track,
+        // redirect to the current active weather overlay.
+        if (!typhoonShown) {
+          this.router.navigateByUrl(
+            this.wuService.getTemperatureShown()
+              ? '/weather-updates/temperature'
+              : '/weather-updates/rainfall-contour'
+          );
+        }
+        break;
+    }
+    this.shown = typhoonShown;
   }
 
-  toggleShown(event: Event) {
+  toggleShown(event: Event): void {
     event.stopPropagation();
     event.stopImmediatePropagation();
 
-    this.shown = !this.shown;
-    this.wuService.toggleTyphoonTrackGroupVisibility(this.shown);
-    this.wuService.toggleWeatherSatelliteVisibility();
-
-    const selectedType = this.wuService.getSelectedRainfallContourType();
-    const tempType = this.wuService.getTemperatureType();
-    // Zoom when shown
-    if (this.shown) {
+    if (!this.shown) {
+      // Turn ON Typhoon Track
+      this.wuService.activateTyphoonTrack();
       this.wuService.triggerZoomToTyphoon();
-    }
-
-    // Update opacity based on route
-    if (
-      this.router.url === '/weather-updates/typhoon-track' ||
-      this.router.url === '/weather-updates/temperature' ||
-      this.router.url === '/weather-updates/rainfall-contour'
-    ) {
-      if (this.shown) {
-        this.wuService.setRainfallContourOpacity(0, selectedType);
-        this.wuService.setTemperatureOpacity(0, tempType);
-      } else {
-        this.wuService.setRainfallContourOpacity(0, selectedType);
-        this.wuService.setTemperatureOpacity(80, tempType);
-      }
-    }
-
-    // ✅ Update URL based on checkbox state
-    if (this.shown) {
       this.router.navigateByUrl('/weather-updates/typhoon-track');
     } else {
-      const activeView = this.wuService.getTemperatureShown()
-        ? '/weather-updates/temperature'
-        : '/weather-updates/rainfall-contour';
-      this.router.navigateByUrl(activeView);
+      // Turn OFF Typhoon Track
+      this.wuService.setTyphoonTrackVisibility(false);
+      this.wuService.setWeatherSatelliteVisibility(false);
+
+      // Navigate back to the active weather overlay
+      this.router.navigateByUrl(this.wuService.getActiveWeatherRoute());
     }
   }
 
@@ -104,12 +101,12 @@ export class TyphoonTrackGroupComponent implements OnInit {
     this.wuService.toggleTyphoonTrackGroupExpansion();
   }
 
-  typhoonTrack() {
-    // Set opacity to 0 for all rainfall contour types
-    ['1hr', '3hr', '6hr', '12hr', '24hr'].forEach((type) => {
-      this.wuService.setRainfallContourOpacity(0, type as any);
-    });
-    this.wuService.enableTyphoonTrackAndSatellite();
-    this.router.navigate(['weather-updates/typhoon-track']);
+  typhoonTrack(): void {
+    this.shown = true;
+
+    this.wuService.activateTyphoonTrack();
+    this.wuService.triggerZoomToTyphoon();
+
+    this.router.navigateByUrl('/weather-updates/typhoon-track');
   }
 }

--- a/src/app/features/weather-updates/components/wu-temperature-group/wu-temperature-group.component.ts
+++ b/src/app/features/weather-updates/components/wu-temperature-group/wu-temperature-group.component.ts
@@ -45,7 +45,6 @@ export class WuTemperatureGroupComponent implements OnInit {
 
   private autoEnableFeatures(): void {
     if (this.router.url === '/weather-updates/temperature') {
-      this.wuService.enableTemperature();
       this.wuService.getTemperatures();
     }
   }

--- a/src/app/features/weather-updates/pages/base/base.component.html
+++ b/src/app/features/weather-updates/pages/base/base.component.html
@@ -26,20 +26,27 @@
         lg:text-4xl
       "
     >
-      <div class="grid grid-cols-[auto,1fr] max-w-xs items-center relative">
-        <!-- First Column: Logo -->
-        <div class="col-span-1" routerLink="/">
+      <a
+        (click)="goHome()"
+        class="
+          grid grid-cols-[auto,1fr]
+          max-w-xs
+          items-center
+          relative
+          cursor-pointer
+        "
+      >
+        <div>
           <img src="assets/icons/logo-noah.svg" class="z-50 w-16 lg:w-20" />
         </div>
 
-        <!-- Second Column: Text -->
-        <div class="col-span-1">
+        <div>
           <img
             src="assets/icons/noah_text.png"
             class="z-50 w-full h-auto object-contain pl-2"
           />
         </div>
-      </div>
+      </a>
     </a>
   </div>
 
@@ -172,7 +179,7 @@
         text-2xl
         lg:text-4xl
       "
-      routerLink="/"
+      (click)="goHome()"
     >
       <div class="flex max-w-xs items-center">
         <img src="assets/icons/noah_logo.png" class="z-50 w-16 lg:w-20" />

--- a/src/app/features/weather-updates/pages/base/base.component.ts
+++ b/src/app/features/weather-updates/pages/base/base.component.ts
@@ -71,13 +71,20 @@ export class BaseComponent implements OnInit {
       }
 
       const activeIndex = swiperRef.activeIndex ?? 0;
+
       this.ngZone.run(() => {
         if (activeIndex === 0) {
-          const url = this.temperatureShown
-            ? '/weather-updates/temperature'
-            : '/weather-updates/rainfall-contour';
-          this.router.navigateByUrl(url);
-        } else if (activeIndex === 1) {
+          if (this.temperatureShown) {
+            this.wuService.activateTemperature();
+            this.router.navigateByUrl('/weather-updates/temperature');
+          } else {
+            this.wuService.activateRainfall();
+            this.router.navigateByUrl('/weather-updates/rainfall-contour');
+          }
+        } else {
+          this.wuService.activateTyphoonTrack();
+          this.wuService.triggerZoomToTyphoon();
+
           this.router.navigateByUrl('/weather-updates/typhoon-track');
         }
       });
@@ -88,19 +95,35 @@ export class BaseComponent implements OnInit {
 
     // Function to safely move swiper based on URL
     const updateSwiperFromUrl = (url: string) => {
-      if (!swiperRef || swiperRef.destroyed) return;
+      if (!swiperRef || swiperRef.destroyed) {
+        return;
+      }
 
       this.ngZone.runOutsideAngular(() => {
+        let targetIndex = 0;
+
         if (url.includes('/weather-updates/typhoon-track')) {
-          this.suppressRouteOnNextSlideChange = true;
-          swiperRef.slideTo(1);
+          targetIndex = 1;
         } else if (
           url.includes('/weather-updates/rainfall-contour') ||
           url.includes('/weather-updates/temperature')
         ) {
-          // Temperature UI is shown within the rainfall slide on mobile.
+          // Rainfall and Temperature share the first slide on mobile.
+          targetIndex = 0;
+        } else {
+          return;
+        }
+        // Mobile only: when returning to the Rainfall/Temperature slide,
+        // restore the default overlay opacity.
+        if (window.innerWidth < 768 && targetIndex === 0) {
+          this.ngZone.run(() => {
+            this.wuService.restoreWeatherOverlays();
+          });
+        }
+        // Only move if the swiper is not already on the correct slide.
+        if (swiperRef.activeIndex !== targetIndex) {
           this.suppressRouteOnNextSlideChange = true;
-          swiperRef.slideTo(0);
+          swiperRef.slideTo(targetIndex);
         }
       });
     };
@@ -120,6 +143,9 @@ export class BaseComponent implements OnInit {
     this.router.events
       .pipe(filter((event) => event instanceof NavigationEnd))
       .subscribe((event: NavigationEnd) => {
+        if (!event.urlAfterRedirects.startsWith('/weather-updates')) {
+          return;
+        }
         updateSwiperFromUrl(event.url);
       });
 
@@ -134,11 +160,29 @@ export class BaseComponent implements OnInit {
     };
   }
 
-  slideNext() {
-    this.swiper?.swiperRef.slideNext();
+  slideNext(): void {
+    this.swiper?.swiperRef.slideTo(1);
+
+    this.wuService.activateTyphoonTrack();
+    this.wuService.triggerZoomToTyphoon();
+
+    this.router.navigateByUrl('/weather-updates/typhoon-track');
   }
 
-  slidePrev() {
-    this.swiper?.swiperRef.slidePrev();
+  slidePrev(): void {
+    this.swiper?.swiperRef.slideTo(0);
+
+    if (this.temperatureShown) {
+      this.wuService.activateTemperature();
+      this.router.navigateByUrl('/weather-updates/temperature');
+    } else {
+      this.wuService.activateRainfall();
+      this.router.navigateByUrl('/weather-updates/rainfall-contour');
+    }
+  }
+
+  goHome(): void {
+    this.wuService.resetWeatherUpdates();
+    this.router.navigateByUrl('/');
   }
 }

--- a/src/app/features/weather-updates/pages/base/base.component.ts
+++ b/src/app/features/weather-updates/pages/base/base.component.ts
@@ -115,11 +115,11 @@ export class BaseComponent implements OnInit {
         }
         // Mobile only: when returning to the Rainfall/Temperature slide,
         // restore the default overlay opacity.
-        if (window.innerWidth < 768 && targetIndex === 0) {
-          this.ngZone.run(() => {
-            this.wuService.restoreWeatherOverlays();
-          });
-        }
+        // if (window.innerWidth < 768 && targetIndex === 0) {
+        //   this.ngZone.run(() => {
+        //     this.wuService.restoreWeatherOverlays();
+        //   });
+        // }
         // Only move if the swiper is not already on the correct slide.
         if (swiperRef.activeIndex !== targetIndex) {
           this.suppressRouteOnNextSlideChange = true;

--- a/src/app/features/weather-updates/services/weather-updates.service.ts
+++ b/src/app/features/weather-updates/services/weather-updates.service.ts
@@ -317,8 +317,6 @@ export class WeatherUpdatesService {
   activateTyphoonTrack(): void {
     this.store.patch(
       {
-        overlayOpacity: 0,
-
         typhoonTrack: {
           ...this.store.state.typhoonTrack,
           shown: true,
@@ -420,15 +418,14 @@ export class WeatherUpdatesService {
           ...this.store.state.temperature,
           shown: false,
         },
-
-        overlayOpacity: 80,
       },
       'Reset Weather Updates'
     );
   }
-  restoreWeatherOverlays(): void {
-    this.setOverlayOpacity(80);
-  }
+
+  // restoreWeatherOverlays(): void {
+  //   this.setOverlayOpacity(80);
+  // }
 
   // TEMPERATURE
 

--- a/src/app/features/weather-updates/services/weather-updates.service.ts
+++ b/src/app/features/weather-updates/services/weather-updates.service.ts
@@ -81,6 +81,18 @@ export class WeatherUpdatesService {
     );
   }
 
+  get overlayOpacity$(): Observable<number> {
+    return this.store.state$.pipe(
+      map((state) => state.overlayOpacity),
+      distinctUntilChanged(),
+      shareReplay(1)
+    );
+  }
+
+  getOverlayOpacity(): number {
+    return this.store.state.overlayOpacity;
+  }
+
   getSelectedRainfallContourType(): RainfallContourTypes {
     return this.store.state.rainfallContourTypes.selectedType;
   }
@@ -162,25 +174,28 @@ export class WeatherUpdatesService {
     opacity: number,
     rainfallContourType: RainfallContourTypes
   ): void {
-    const rainfallContourTypes: RainfallContourState = {
-      ...this.store.state.rainfallContourTypes,
-      fade: {
-        ...this.store.state.rainfallContourTypes.fade,
-        [rainfallContourType]: { opacity },
-      },
-    };
+    this.setOverlayOpacity(opacity);
+  }
+
+  setOverlayOpacity(opacity: number): void {
+    console.trace('setOverlayOpacity', opacity);
+
     this.store.patch(
-      { rainfallContourTypes },
-      `Rainfall Contour - update ${rainfallContourType}'s opacity to ${opacity}`
+      {
+        overlayOpacity: opacity,
+      },
+      `Overlay opacity set to ${opacity}`
     );
+  }
+
+  hideWeatherOverlays(): void {
+    this.setOverlayOpacity(0);
   }
 
   getRainfallContour$(
     rainfallContourType: RainfallContourTypes
   ): Observable<{ opacity: number }> {
-    return this.store.state$.pipe(
-      map((state) => state.rainfallContourTypes.fade[rainfallContourType])
-    );
+    return this.overlayOpacity$.pipe(map((opacity) => ({ opacity })));
   }
 
   // Getters for Typhoon Track.
@@ -299,40 +314,58 @@ export class WeatherUpdatesService {
   }
 
   // Enable both typhoon track and himawari satellite
-  enableTyphoonTrackAndSatellite(): void {
-    // Enable typhoon track
-    const typhoonTrack = {
-      ...this.store.state.typhoonTrack,
-      shown: true,
-      expanded: true,
-    };
-
-    // Enable weather satellite (himawari)
-    const weatherSatellite = {
-      ...this.store.state.weatherSatellite,
-      shown: true,
-      expanded: true,
-      selectedType: 'himawari' as WeatherSatelliteType,
-    };
-
-    // Update both states
+  activateTyphoonTrack(): void {
     this.store.patch(
       {
-        typhoonTrack,
-        weatherSatellite,
+        overlayOpacity: 0,
+
+        typhoonTrack: {
+          ...this.store.state.typhoonTrack,
+          shown: true,
+          expanded: true,
+        },
+
+        weatherSatellite: {
+          ...this.store.state.weatherSatellite,
+          shown: true,
+          expanded: true,
+        },
       },
-      'Enable typhoon track and himawari satellite from landing page'
+      'Activate Typhoon Track and Himawari Satellite'
     );
   }
 
-  enableTemperature(): void {
-    const temperature = {
-      ...this.store.state.temperature,
-      shown: true,
-      expanded: true,
-    };
+  activateRainfall(): void {
+    this.store.patch(
+      {
+        rainfallContourTypes: {
+          ...this.store.state.rainfallContourTypes,
+          shown: true,
+        },
+        temperature: {
+          ...this.store.state.temperature,
+          shown: false,
+        },
+      },
+      'Activate Rainfall'
+    );
+  }
 
-    this.store.patch({ temperature }, `Enable Temperature from landing page`);
+  activateTemperature(): void {
+    this.store.patch(
+      {
+        rainfallContourTypes: {
+          ...this.store.state.rainfallContourTypes,
+          shown: false,
+        },
+        temperature: {
+          ...this.store.state.temperature,
+          shown: true,
+          expanded: true,
+        },
+      },
+      'Activate Temperature'
+    );
   }
 
   //explicitly set typhoon track visibility
@@ -344,21 +377,6 @@ export class WeatherUpdatesService {
     this.store.patch(
       { typhoonTrack },
       `Set typhoon track visibility to ${visible}`
-    );
-  }
-
-  setTemperatureVisibility(visible: boolean): void {
-    const temperature = {
-      ...this.store.state.temperature,
-      shown: visible,
-    };
-    const rainfallContourTypes = {
-      ...this.store.state.rainfallContourTypes,
-      shown: !visible,
-    };
-    this.store.patch(
-      { temperature, rainfallContourTypes },
-      `Set Temperature visibility to ${visible}`
     );
   }
 
@@ -378,6 +396,40 @@ export class WeatherUpdatesService {
     this.zoomTyphoon.next();
   }
 
+  resetWeatherUpdates(): void {
+    this.store.patch(
+      {
+        typhoonTrack: {
+          ...this.store.state.typhoonTrack,
+          shown: false,
+          expanded: false,
+        },
+
+        weatherSatellite: {
+          ...this.store.state.weatherSatellite,
+          shown: false,
+          expanded: false,
+        },
+
+        rainfallContourTypes: {
+          ...this.store.state.rainfallContourTypes,
+          shown: true,
+        },
+
+        temperature: {
+          ...this.store.state.temperature,
+          shown: false,
+        },
+
+        overlayOpacity: 80,
+      },
+      'Reset Weather Updates'
+    );
+  }
+  restoreWeatherOverlays(): void {
+    this.setOverlayOpacity(80);
+  }
+
   // TEMPERATURE
 
   getTemperatures(): TemperatureState {
@@ -388,48 +440,46 @@ export class WeatherUpdatesService {
   }
 
   getTemperature$(type: TemperatureType): Observable<TemperatureTypeState> {
-    return this.store.state$.pipe(
-      map((state) => state.temperature.types[type])
+    return this.overlayOpacity$.pipe(
+      map((opacity) => ({
+        opacity,
+        fetched: this.store.state.temperature.types[type].fetched,
+      }))
     );
   }
 
   getTemperatureOpacity(type: TemperatureType): number {
-    return this.store.state.temperature.types[type].opacity;
+    return this.store.state.overlayOpacity;
   }
 
-  setTemperatureOpacity(opacity: number, type: TemperatureType) {
-    const temperature: TemperatureState = {
-      ...this.store.state.temperature,
-      types: {
-        ...this.store.state.temperature.types,
-        [type]: {
-          ...this.store.state.temperature.types[type],
-          opacity,
-        },
-      },
-    };
+  getActiveWeatherRoute(): string {
+    return this.getTemperatureShown()
+      ? '/weather-updates/temperature'
+      : '/weather-updates/rainfall-contour';
+  }
 
-    this.store.patch(
-      { temperature },
-      `Temperature - set to ${type} and Opacity to ${opacity}`
-    );
+  setTemperatureOpacity(opacity: number, type: TemperatureType): void {
+    this.setOverlayOpacity(opacity);
   }
 
   selectTemperatureType(tempType: TemperatureType): void {
-    const temperature = {
-      ...this.store.state.temperature,
-      shown: true,
-    };
-    const rainfallContourTypes = {
-      ...this.store.state.rainfallContourTypes,
-      shown: false,
-    };
-
-    temperature.selectedType = tempType;
+    console.log('Before patch:', this.store.state);
     this.store.patch(
-      { temperature, rainfallContourTypes },
+      {
+        temperature: {
+          ...this.store.state.temperature,
+          shown: true,
+          expanded: true,
+          selectedType: tempType,
+        },
+        rainfallContourTypes: {
+          ...this.store.state.rainfallContourTypes,
+          shown: false,
+        },
+      },
       `Select Temperature Type: ${tempType}`
     );
+    console.log('After patch:', this.store.state);
   }
 
   selectTemperatureForecastDay(day: TemperatureForecastDay): void {

--- a/src/app/features/weather-updates/store/weather-updates.store.ts
+++ b/src/app/features/weather-updates/store/weather-updates.store.ts
@@ -94,6 +94,7 @@ type WeatherUpdatesState = {
   center: { lng: number; lat: number };
   currentCoords: { lng: number; lat: number };
   currentLocation: string;
+  overlayOpacity: number;
   rainfallContourTypes: RainfallContourState;
   typhoonTrack: TyphoonTrackState;
   weatherSatellite: WeatherSatelliteState;
@@ -106,6 +107,7 @@ const createInitialValue = (): WeatherUpdatesState => {
     center: null,
     currentCoords: PH_DEFAULT_CENTER,
     currentLocation: '',
+    overlayOpacity: 80,
     rainfallContourTypes: {
       shown: true,
       selectedType: '1hr',

--- a/src/app/features/weather-updates/weather-updates.module.ts
+++ b/src/app/features/weather-updates/weather-updates.module.ts
@@ -13,6 +13,8 @@ import { RainfallContourButtonComponent } from './components/rainfall-contour-bu
 import { TyphoonTrackGroupComponent } from './components/typhoon-track-group/typhoon-track-group.component';
 import { TyphoonTrackSoloComponent } from './components/typhoon-track-solo/typhoon-track-solo.component';
 import { WeatherSatelliteComponent } from './components/weather-satellite/weather-satellite.component';
+import { WuTemperatureGroupComponent } from './components/wu-temperature-group/wu-temperature-group.component';
+import { WuTemperatureSoloComponent } from './components/wu-temperature-solo/wu-temperature-solo.component';
 
 @NgModule({
   declarations: [
@@ -23,6 +25,8 @@ import { WeatherSatelliteComponent } from './components/weather-satellite/weathe
     TyphoonTrackGroupComponent,
     TyphoonTrackSoloComponent,
     WeatherSatelliteComponent,
+    WuTemperatureGroupComponent,
+    WuTemperatureSoloComponent,
   ],
   imports: [
     CommonModule,


### PR DESCRIPTION
### Update:

- update swiperSlide 
- - Typhoon Track is active if you click Next button and Typhoon Track icon in Landing Page
- - Rainfall/Temperature is active is Previous button is selected or whichever weather layer was previously active
- Update Opacity for Rainfall/Temperature
- Router behavior
- If Typhoon Track is ON and the user moves the opacity slider, Rainfall/Temperature should appear together with the Typhoon Track with the same state
- Both mobile and desktop view retail the state of the opacity value if Typhoon Track is active
- If the user already moved the slider (e.g. to 35), the opacity stays at 35 and is not overwritten for Rainfall Contour and Temperature both desktop and mobile